### PR TITLE
Add proxy plugin system with Copilot provider

### DIFF
--- a/docs/proxy-plugin-api.md
+++ b/docs/proxy-plugin-api.md
@@ -1,0 +1,141 @@
+# Proxy Plugin API
+
+// [LAW:one-source-of-truth] This document is the canonical contract for pluggable proxy providers.
+
+## Goals
+
+- Provider complexity is isolated from core proxy pipeline code.
+- Provider failures are contained and cannot crash `cc-dump`.
+- Provider settings are declared by providers and rendered by `cc-dump` generically.
+- Core `cc-dump` code does not depend on provider internals.
+
+## Contract
+
+Defined in `/Users/bmf/code/cc-dump/src/cc_dump/proxies/plugin_api.py`.
+
+### `ProxySettingDescriptor`
+
+Provider-declared setting metadata:
+
+- `key`
+- `label`
+- `description`
+- `kind`: `text | bool | select`
+- `default`
+- `options` (for `select`)
+- `secret`
+- `env_vars`
+
+### `ProxyProviderDescriptor`
+
+- `provider_id`
+- `display_name`
+- `settings` (tuple of `ProxySettingDescriptor`)
+
+### `ProxyRequestContext`
+
+Runtime context passed from core pipeline to plugin handler:
+
+- `request_id`
+- `request_path`
+- `request_body`
+- `method`
+- `request_headers`
+- `runtime_snapshot`
+- `handler`
+- `event_queue`
+- `safe_headers`
+
+### `ProxyProviderPlugin`
+
+Required plugin API:
+
+1. `descriptor` property
+2. `handles_path(request_path) -> bool`
+3. `expects_json_body(request_path) -> bool`
+4. `handle_request(context) -> bool`
+
+`handle_request` returns:
+
+- `True`: plugin handled request/response lifecycle
+- `False`: core pipeline should continue default upstream behavior
+
+### Plugin module contract
+
+Each plugin package must expose a factory in
+`/Users/bmf/code/cc-dump/src/cc_dump/proxies/<provider>/plugin.py`:
+
+- `create_plugin() -> ProxyProviderPlugin`
+
+Registry discovery is file-system driven (`*/plugin.py`) and does not hardcode provider imports.
+
+### Optional auth capability
+
+`ProxyAuthCapablePlugin`:
+
+- `run_auth_flow(force: bool) -> ProxyAuthResult`
+
+## Core Integration Points
+
+### Registry
+
+`/Users/bmf/code/cc-dump/src/cc_dump/proxies/registry.py`
+
+- Single registration point for provider descriptors and plugins
+- Generic plugin discovery via `create_plugin()` factories
+- Descriptor-driven env override application
+- Provider lookup for runtime dispatch
+- Import/factory failures are contained and exposed through `plugin_load_errors()`
+
+### Runtime
+
+`/Users/bmf/code/cc-dump/src/cc_dump/proxies/runtime.py`
+
+- Stores one canonical provider + settings snapshot
+- Exposes provider-agnostic setting accessors
+- Computes active base URL generically
+
+### Settings
+
+- Schema assembly: `/Users/bmf/code/cc-dump/src/cc_dump/app/settings_store.py`
+- UI field assembly: `/Users/bmf/code/cc-dump/src/cc_dump/tui/settings_panel.py`
+
+Both consume provider descriptors; no provider-specific field wiring exists in core code.
+
+### Proxy pipeline
+
+`/Users/bmf/code/cc-dump/src/cc_dump/pipeline/proxy.py`
+
+- Looks up active provider plugin by `provider_id`
+- Delegates by contract only
+- Wraps plugin invocation in hard exception boundary
+
+// [LAW:single-enforcer] Plugin crash containment is enforced at this one dispatch boundary.
+
+## Conformance
+
+### `cc-dump` core conformance
+
+- Uses registry/provider descriptor APIs for provider settings and env overrides.
+- Uses plugin API (`handles_path`, `expects_json_body`, `handle_request`) for request handling.
+- Contains plugin failures to isolated 502 responses.
+- Contains plugin load-time failures in registry bootstrap (app still starts with healthy providers).
+
+### Copilot plugin conformance
+
+`/Users/bmf/code/cc-dump/src/cc_dump/proxies/copilot/plugin.py` implements:
+
+- `descriptor`
+- `handles_path`
+- `expects_json_body`
+- `handle_request`
+- `run_auth_flow` (optional auth capability)
+- `create_plugin` (required discovery factory)
+
+## Verification
+
+- Contract/registry tests:
+  - `/Users/bmf/code/cc-dump/tests/test_proxy_registry.py`
+  - `/Users/bmf/code/cc-dump/tests/test_proxy_plugin_boundary.py`
+- Copilot route contract tests:
+  - `/Users/bmf/code/cc-dump/tests/test_copilot_proxy_routes.py`

--- a/proxies/copilot/IMPLEMENTATION_EVALUATION.md
+++ b/proxies/copilot/IMPLEMENTATION_EVALUATION.md
@@ -1,0 +1,97 @@
+# Copilot Support: Slice-by-Slice Evaluation
+
+## Scope
+This evaluates the Copilot proxy work implemented so far in `cc-dump`, relative to the reference behavior in `/Users/bmf/code/ericc-ch_copilot-api` and current product goals (live configurability, route compatibility, and robust proxy behavior).
+
+## Summary
+- Overall status: **strong partial completion**.
+- Core capabilities are implemented and tested.
+- Remaining work is mostly around production-hardening and deeper integration tests (real upstream behavior under failure/latency/stream edge cases).
+
+## Slice Status Matrix
+
+| Slice | Status | Evidence | Notes |
+|---|---|---|---|
+| Runtime provider abstraction (`anthropic`/`copilot`) | Complete | `src/cc_dump/proxies/runtime.py`, `tests/test_proxy_runtime.py` | Provider switching and normalization are in place. |
+| Settings schema + reactive runtime sync | Complete | `src/cc_dump/app/settings_store.py`, `src/cc_dump/tui/settings_panel.py` | Includes Copilot fields, secrets, and runtime update reaction. |
+| CLI startup/env wiring for Copilot | Complete | `src/cc_dump/cli.py` | Supports env overrides including rate-limit settings. |
+| Device auth flow (`--copilot-auth`) | Complete | `src/cc_dump/proxies/copilot/auth.py`, `tests/test_copilot_auth.py` | Persists GitHub token and performs preflight token resolution. |
+| Token resolution and refresh via GitHub endpoint | Complete | `src/cc_dump/proxies/copilot/token_manager.py`, `tests/test_copilot_token_manager.py` | Explicit token preferred, GitHub fallback cached/refreshed. |
+| Anthropic->OpenAI request translation | Complete | `src/cc_dump/proxies/copilot/translation.py`, `tests/test_copilot_translation.py` | Handles system, text, thinking, tool use/result, tool choices. |
+| OpenAI->Anthropic response translation (non-stream) | Complete | `src/cc_dump/proxies/copilot/translation.py`, `tests/test_copilot_translation.py` | Maps usage and stop reasons. |
+| Streaming translation to Anthropic SSE events | Complete | `src/cc_dump/proxies/copilot/translation.py`, `src/cc_dump/pipeline/proxy.py` | Includes tool call deltas, message lifecycle, error SSE fallback. |
+| Copilot endpoint handling in proxy | Complete | `src/cc_dump/pipeline/proxy.py` | Routes implemented for messages/models/chat/embeddings/usage/token/count_tokens. |
+| OpenAI compatibility alias routes | Complete | `src/cc_dump/pipeline/proxy.py`, `tests/test_copilot_proxy_routes.py` | Includes `/chat/completions`, `/embeddings`, `/models` and v1 forms. |
+| Utility alias routes (`/v1/usage`, `/v1/token`) | Complete | `src/cc_dump/pipeline/proxy.py`, `tests/test_copilot_proxy_routes.py` | Added in latest slice for compatibility consistency. |
+| Copilot request rate limiting | Complete | `src/cc_dump/proxies/copilot/rate_limit.py`, `tests/test_copilot_rate_limit.py` | Supports reject mode (429) and wait mode. |
+| Count-tokens endpoint heuristic + fallback | Complete | `src/cc_dump/proxies/copilot/provider.py`, `tests/test_copilot_provider.py` | Uses heuristic and now returns safe fallback on translation/count failures. |
+| Docs scaffolding for Copilot area | Partial | `proxies/copilot/README.md` | Functional but still minimal compared to implementation breadth. |
+
+## Endpoint Parity Snapshot
+
+| Endpoint | Status in `cc-dump` |
+|---|---|
+| `POST /v1/messages` | Implemented (translation + stream/non-stream) |
+| `POST /v1/messages/count_tokens` | Implemented (heuristic + fallback) |
+| `GET /v1/models` | Implemented (Anthropic-shaped translation) |
+| `GET /models` | Implemented (OpenAI passthrough) |
+| `POST /v1/chat/completions` | Implemented (OpenAI passthrough) |
+| `POST /chat/completions` | Implemented (alias) |
+| `POST /v1/embeddings` | Implemented (OpenAI passthrough) |
+| `POST /embeddings` | Implemented (alias) |
+| `GET /usage` | Implemented (GitHub endpoint passthrough) |
+| `GET /v1/usage` | Implemented (alias) |
+| `GET /token` | Implemented (resolved token endpoint) |
+| `GET /v1/token` | Implemented (alias) |
+
+## Quality/Verification Snapshot
+
+- Copilot-focused tests currently pass:
+  - `tests/test_copilot_auth.py`
+  - `tests/test_copilot_token_manager.py`
+  - `tests/test_copilot_provider.py`
+  - `tests/test_copilot_translation.py`
+  - `tests/test_copilot_proxy_routes.py`
+  - `tests/test_copilot_rate_limit.py`
+  - `tests/test_proxy_runtime.py`
+- Regression subset also passes:
+  - `tests/test_sentinel.py`
+  - `tests/test_har_recorder.py`
+  - `tests/test_event_types.py`
+
+## Key Risks / Gaps Remaining
+
+1. Integration realism gap:
+   - Current tests are mostly unit-level/mocked.
+   - Missing an end-to-end test harness against realistic upstream SSE edge patterns.
+
+2. Error-shape consistency across non-Anthropic passthrough routes:
+   - `/v1/messages` has explicit Anthropic-shaped error mapping.
+   - Other passthrough routes mostly relay upstream payloads directly.
+   - This is acceptable, but should be explicitly standardized by contract.
+
+3. Docs gap:
+   - Operator-facing guidance (auth precedence, route semantics, and troubleshooting) is still lightweight.
+
+4. Proxy handler complexity:
+   - Copilot handling inside `src/cc_dump/pipeline/proxy.py` is large.
+   - Functional now, but should be decomposed into endpoint handlers for maintainability.
+
+## Recommended Next Slices
+
+1. Add integration tests for streaming edge cases:
+   - partial JSON deltas
+   - malformed SSE lines
+   - mid-stream upstream disconnects
+
+2. Extract Copilot route handlers from `pipeline/proxy.py` into dedicated module(s) to reduce complexity and improve testability.
+
+3. Define and enforce explicit error-shape policy per endpoint family:
+   - Anthropic-compatible endpoints
+   - OpenAI-compatible endpoints
+   - utility/debug endpoints
+
+4. Expand Copilot operator docs:
+   - auth/token precedence
+   - rate-limit behavior matrix
+   - provider-switching examples

--- a/proxies/copilot/README.md
+++ b/proxies/copilot/README.md
@@ -1,0 +1,27 @@
+# Copilot Proxy Work Area
+
+This directory holds Copilot-provider notes and assets for `cc-dump`.
+
+- Runtime implementation lives in `/Users/bmf/code/cc-dump/src/cc_dump/proxies/copilot/`.
+- This root-level folder is reserved for provider-specific docs/templates as we iterate.
+
+Current supported routes in `provider=copilot` mode:
+- `POST /v1/messages` (Anthropic-compatible; translated to Copilot chat-completions)
+- `POST /v1/messages/count_tokens` (heuristic count endpoint)
+- `GET /v1/models` (translated to Anthropic model-list shape)
+- `GET /models` (OpenAI-style model list passthrough)
+- `POST /v1/chat/completions` (OpenAI-compatible passthrough to Copilot)
+- `POST /chat/completions` (OpenAI-compatible passthrough alias)
+- `POST /v1/embeddings` (OpenAI-compatible passthrough to Copilot embeddings)
+- `POST /embeddings` (OpenAI-compatible passthrough alias)
+- `GET /usage` (GitHub Copilot usage endpoint passthrough)
+- `GET /v1/usage` (compatibility alias)
+- `GET /token` (resolved Copilot token visibility for debugging)
+- `GET /v1/token` (compatibility alias)
+
+Auth modes:
+- `proxy_copilot_token`: direct Copilot bearer token
+- `proxy_copilot_github_token`: GitHub token used to fetch/refresh Copilot token
+- `proxy_copilot_rate_limit_seconds`: minimum interval between Copilot upstream calls
+- `proxy_copilot_rate_limit_wait`: wait instead of returning 429 when rate limit is hit
+- CLI helper: `cc-dump --proxy-auth copilot` runs GitHub device auth and saves provider settings

--- a/src/cc_dump/proxies/__init__.py
+++ b/src/cc_dump/proxies/__init__.py
@@ -1,0 +1,5 @@
+"""Proxy providers and runtime routing support."""
+
+from cc_dump.proxies import registry
+
+__all__ = ["registry"]

--- a/src/cc_dump/proxies/copilot/__init__.py
+++ b/src/cc_dump/proxies/copilot/__init__.py
@@ -1,0 +1,5 @@
+"""Copilot upstream adapter and translation helpers."""
+
+from cc_dump.proxies.copilot.plugin import CopilotProxyPlugin
+
+__all__ = ["CopilotProxyPlugin"]

--- a/src/cc_dump/proxies/copilot/api_config.py
+++ b/src/cc_dump/proxies/copilot/api_config.py
@@ -1,0 +1,58 @@
+"""Copilot API configuration helpers.
+
+Ported from the reference proxy implementation's core header/base-url behavior.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from uuid import uuid4
+
+
+COPILOT_VERSION = "0.26.7"
+EDITOR_PLUGIN_VERSION = f"copilot-chat/{COPILOT_VERSION}"
+USER_AGENT = f"GitHubCopilotChat/{COPILOT_VERSION}"
+API_VERSION = "2025-04-01"
+
+
+@dataclass(frozen=True)
+class CopilotAuthConfig:
+    token: str
+    account_type: str = "individual"
+    base_url: str = ""
+    vscode_version: str = "1.99.0"
+
+
+def resolve_copilot_base_url(config: CopilotAuthConfig) -> str:
+    configured = str(config.base_url or "").strip().rstrip("/")
+    if configured:
+        return configured
+    account_type = str(config.account_type or "individual").strip().lower()
+    if account_type == "individual":
+        return "https://api.githubcopilot.com"
+    return f"https://api.{account_type}.githubcopilot.com"
+
+
+def build_copilot_headers(
+    *,
+    config: CopilotAuthConfig,
+    vision: bool = False,
+    agent_initiator: bool = False,
+) -> dict[str, str]:
+    headers = {
+        "Authorization": f"Bearer {config.token}",
+        "content-type": "application/json",
+        "accept": "application/json",
+        "copilot-integration-id": "vscode-chat",
+        "editor-version": f"vscode/{config.vscode_version}",
+        "editor-plugin-version": EDITOR_PLUGIN_VERSION,
+        "user-agent": USER_AGENT,
+        "openai-intent": "conversation-panel",
+        "x-github-api-version": API_VERSION,
+        "x-request-id": str(uuid4()),
+        "x-vscode-user-agent-library-version": "electron-fetch",
+        "X-Initiator": "agent" if agent_initiator else "user",
+    }
+    if vision:
+        headers["copilot-vision-request"] = "true"
+    return headers

--- a/src/cc_dump/proxies/copilot/auth.py
+++ b/src/cc_dump/proxies/copilot/auth.py
@@ -1,0 +1,89 @@
+"""GitHub device auth flow for Copilot proxy credentials."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import time
+import urllib.error
+import urllib.request
+
+
+GITHUB_BASE_URL = "https://github.com"
+GITHUB_CLIENT_ID = "Iv1.b507a08c87ecfe98"
+GITHUB_APP_SCOPES = "read:user"
+
+
+@dataclass(frozen=True)
+class DeviceCodeResponse:
+    device_code: str
+    user_code: str
+    verification_uri: str
+    expires_in: int
+    interval: int
+
+
+def _json_request(url: str, *, body: dict[str, object]) -> dict[str, object]:
+    payload = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=payload,
+        headers={
+            "content-type": "application/json",
+            "accept": "application/json",
+        },
+        method="POST",
+    )
+    response = urllib.request.urlopen(request, timeout=30)
+    raw = response.read().decode("utf-8")
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError:
+        parsed = {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def get_device_code() -> DeviceCodeResponse:
+    data = _json_request(
+        f"{GITHUB_BASE_URL}/login/device/code",
+        body={"client_id": GITHUB_CLIENT_ID, "scope": GITHUB_APP_SCOPES},
+    )
+    return DeviceCodeResponse(
+        device_code=str(data.get("device_code", "")),
+        user_code=str(data.get("user_code", "")),
+        verification_uri=str(data.get("verification_uri", "")),
+        expires_in=int(data.get("expires_in", 0) or 0),
+        interval=int(data.get("interval", 5) or 5),
+    )
+
+
+def poll_access_token(device_code: DeviceCodeResponse) -> str:
+    started_at = time.time()
+    sleep_seconds = max(1, device_code.interval + 1)
+    while True:
+        if device_code.expires_in > 0 and (time.time() - started_at) > device_code.expires_in:
+            raise RuntimeError("GitHub device code expired before authorization completed")
+
+        data = _json_request(
+            f"{GITHUB_BASE_URL}/login/oauth/access_token",
+            body={
+                "client_id": GITHUB_CLIENT_ID,
+                "device_code": device_code.device_code,
+                "grant_type": "urn:ietf:params:oauth:grant-type:device_code",
+            },
+        )
+        token = str(data.get("access_token", "")).strip()
+        if token:
+            return token
+        error = str(data.get("error", "")).strip()
+        if error and error not in {"authorization_pending", "slow_down"}:
+            raise RuntimeError(f"GitHub device auth failed: {error}")
+        time.sleep(sleep_seconds)
+
+
+def run_device_auth_flow() -> tuple[DeviceCodeResponse, str]:
+    device_code = get_device_code()
+    if not device_code.user_code or not device_code.verification_uri:
+        raise RuntimeError("GitHub device code flow returned invalid response")
+    access_token = poll_access_token(device_code)
+    return device_code, access_token

--- a/src/cc_dump/proxies/copilot/plugin.py
+++ b/src/cc_dump/proxies/copilot/plugin.py
@@ -1,0 +1,765 @@
+"""Copilot proxy plugin implementation.
+
+// [LAW:locality-or-seam] Provider-specific HTTP behavior is isolated to this module.
+"""
+
+from __future__ import annotations
+
+import json
+import ssl
+import time
+import urllib.error
+import urllib.request
+
+import cc_dump.io.settings
+from cc_dump.pipeline.event_types import (
+    ErrorEvent,
+    ProxyErrorEvent,
+    ResponseCompleteEvent,
+    ResponseDoneEvent,
+    ResponseHeadersEvent,
+    ResponseProgressEvent,
+    parse_sse_event,
+    sse_progress_payload,
+)
+from cc_dump.pipeline.response_assembler import ResponseAssembler
+from cc_dump.proxies.copilot import provider as copilot_provider
+from cc_dump.proxies.copilot.auth import run_device_auth_flow
+from cc_dump.proxies.copilot.rate_limit import copilot_rate_limiter
+from cc_dump.proxies.copilot.token_manager import resolve_copilot_token
+from cc_dump.proxies.plugin_api import (
+    ProxyAuthResult,
+    ProxyProviderDescriptor,
+    ProxyProviderPlugin,
+    ProxyRequestContext,
+    ProxySettingDescriptor,
+)
+from cc_dump.proxies.runtime import ProxyRuntime
+
+
+_COPILOT_MESSAGES_PATH = "/v1/messages"
+_COPILOT_COUNT_TOKENS_PATH = "/v1/messages/count_tokens"
+_COPILOT_MODELS_PATHS = frozenset(("/v1/models", "/models"))
+_COPILOT_CHAT_PATHS = frozenset(("/v1/chat/completions", "/chat/completions"))
+_COPILOT_EMBEDDINGS_PATHS = frozenset(("/v1/embeddings", "/embeddings"))
+_COPILOT_USAGE_PATHS = frozenset(("/usage", "/v1/usage"))
+_COPILOT_TOKEN_PATHS = frozenset(("/token", "/v1/token"))
+_COPILOT_SUPPORTED_PATHS = frozenset(
+    {
+        _COPILOT_MESSAGES_PATH,
+        _COPILOT_COUNT_TOKENS_PATH,
+        *_COPILOT_MODELS_PATHS,
+        *_COPILOT_CHAT_PATHS,
+        *_COPILOT_EMBEDDINGS_PATHS,
+        *_COPILOT_USAGE_PATHS,
+        *_COPILOT_TOKEN_PATHS,
+    }
+)
+_COPILOT_RATE_LIMITED_PATHS = frozenset(
+    {
+        _COPILOT_MESSAGES_PATH,
+        *_COPILOT_MODELS_PATHS,
+        *_COPILOT_CHAT_PATHS,
+        *_COPILOT_EMBEDDINGS_PATHS,
+        *_COPILOT_USAGE_PATHS,
+    }
+)
+_JSON_BODY_PATHS = frozenset(
+    {
+        _COPILOT_MESSAGES_PATH,
+        _COPILOT_COUNT_TOKENS_PATH,
+        *_COPILOT_CHAT_PATHS,
+        *_COPILOT_EMBEDDINGS_PATHS,
+    }
+)
+
+
+class CopilotProxyPlugin(ProxyProviderPlugin):
+    @property
+    def descriptor(self) -> ProxyProviderDescriptor:
+        return ProxyProviderDescriptor(
+            provider_id="copilot",
+            display_name="Copilot",
+            settings=(
+                ProxySettingDescriptor(
+                    key="proxy_copilot_base_url",
+                    label="Copilot URL",
+                    description="Base URL when provider=copilot",
+                    kind="text",
+                    default="https://api.githubcopilot.com",
+                    env_vars=("CC_DUMP_COPILOT_BASE_URL",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_account_type",
+                    label="Copilot Account",
+                    description="individual | business | enterprise",
+                    kind="select",
+                    default="individual",
+                    options=("individual", "business", "enterprise"),
+                    env_vars=("CC_DUMP_COPILOT_ACCOUNT_TYPE",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_vscode_version",
+                    label="VSCode Version",
+                    description="Editor version string sent to Copilot API",
+                    kind="text",
+                    default="1.99.0",
+                    env_vars=("CC_DUMP_COPILOT_VSCODE_VERSION",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_rate_limit_seconds",
+                    label="Rate Limit (s)",
+                    description="Minimum seconds between Copilot upstream calls (0 disables)",
+                    kind="text",
+                    default=0,
+                    env_vars=("CC_DUMP_COPILOT_RATE_LIMIT_SECONDS",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_rate_limit_wait",
+                    label="Wait On Limit",
+                    description="When rate-limited, wait instead of returning 429",
+                    kind="bool",
+                    default=False,
+                    env_vars=("CC_DUMP_COPILOT_RATE_LIMIT_WAIT",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_token",
+                    label="Copilot Token",
+                    description="Bearer token used for Copilot upstream requests",
+                    kind="text",
+                    default="",
+                    secret=True,
+                    env_vars=("GITHUB_COPILOT_TOKEN",),
+                ),
+                ProxySettingDescriptor(
+                    key="proxy_copilot_github_token",
+                    label="GitHub Token",
+                    description="Fallback: fetch/refresh Copilot token from GitHub API",
+                    kind="text",
+                    default="",
+                    secret=True,
+                    env_vars=("CC_DUMP_COPILOT_GITHUB_TOKEN", "GITHUB_TOKEN"),
+                ),
+            ),
+        )
+
+    def handles_path(self, request_path: str) -> bool:
+        return request_path in _COPILOT_SUPPORTED_PATHS
+
+    def expects_json_body(self, request_path: str) -> bool:
+        return request_path in _JSON_BODY_PATHS
+
+    def run_auth_flow(self, *, force: bool) -> ProxyAuthResult:
+        existing = str(cc_dump.io.settings.load_setting("proxy_copilot_github_token", "") or "").strip()
+        if existing and not force:
+            raise RuntimeError("Copilot GitHub token already configured. Use --proxy-auth-force to replace it.")
+        device_code, github_token = run_device_auth_flow()
+        runtime = ProxyRuntime()
+        runtime.update_from_settings(
+            {
+                "proxy_provider": "copilot",
+                "proxy_anthropic_base_url": "https://api.anthropic.com",
+                "proxy_copilot_base_url": "https://api.githubcopilot.com",
+                "proxy_copilot_token": "",
+                "proxy_copilot_github_token": github_token,
+                "proxy_copilot_account_type": "individual",
+                "proxy_copilot_vscode_version": "1.99.0",
+                "proxy_copilot_rate_limit_seconds": 0,
+                "proxy_copilot_rate_limit_wait": False,
+            }
+        )
+        token, error = resolve_copilot_token(runtime.snapshot())
+        summary = (
+            f"Authorized via device code {device_code.user_code} at {device_code.verification_uri}."
+            if not error
+            else (
+                "Authorized, but Copilot token preflight failed: {}".format(error)
+            )
+        )
+        if not error:
+            summary += f" Copilot token preflight success (len={len(token)})."
+        return ProxyAuthResult(
+            settings_updates={
+                "proxy_provider": "copilot",
+                "proxy_copilot_github_token": github_token,
+            },
+            message=summary,
+        )
+
+    def handle_request(self, context: ProxyRequestContext) -> bool:
+        if not self.handles_path(context.request_path):
+            return False
+
+        runtime_snapshot = context.runtime_snapshot
+        request_id = context.request_id
+        handler = context.handler
+        body = context.request_body
+        request_path = context.request_path
+
+        if request_path in _COPILOT_RATE_LIMITED_PATHS:
+            allowed, remaining = copilot_rate_limiter.gate(
+                min_interval_seconds=runtime_snapshot.get_int("proxy_copilot_rate_limit_seconds", 0),
+                wait_on_limit=runtime_snapshot.get_bool("proxy_copilot_rate_limit_wait", False),
+            )
+            if not allowed:
+                message = (
+                    "Copilot provider rate limit active; retry in {:.2f}s "
+                    "(set proxy_copilot_rate_limit_wait=true to auto-wait)"
+                ).format(remaining)
+                context.event_queue.put(
+                    ErrorEvent(
+                        code=429,
+                        reason=message,
+                        request_id=request_id,
+                        recv_ns=time.monotonic_ns(),
+                    )
+                )
+                handler.send_response(429)
+                handler.send_header("content-type", "application/json")
+                handler.send_header("retry-after", str(int(max(1.0, remaining))))
+                handler.end_headers()
+                handler.wfile.write(
+                    json.dumps(
+                        {
+                            "type": "error",
+                            "error": {
+                                "type": "rate_limit_error",
+                                "message": message,
+                            },
+                        }
+                    ).encode("utf-8")
+                )
+                return True
+
+        if self.expects_json_body(request_path) and not isinstance(body, dict):
+            context.event_queue.put(
+                ErrorEvent(
+                    code=400,
+                    reason="Malformed JSON request body for Copilot provider",
+                    request_id=request_id,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            handler.send_response(400)
+            handler.send_header("content-type", "application/json")
+            handler.end_headers()
+            handler.wfile.write(
+                json.dumps(
+                    {
+                        "type": "error",
+                        "error": {
+                            "type": "invalid_request_error",
+                            "message": "Request body must be valid JSON object",
+                        },
+                    }
+                ).encode("utf-8")
+            )
+            return True
+
+        if request_path == _COPILOT_COUNT_TOKENS_PATH:
+            payload = dict(body)
+            beta_header = str(handler.headers.get("anthropic-beta", "")).strip()
+            if beta_header:
+                payload["_anthropic_beta"] = beta_header
+            token_count = copilot_provider.count_tokens_for_messages(payload)
+            response_body = {"input_tokens": token_count}
+            data = json.dumps(response_body).encode("utf-8")
+            handler.send_response(200)
+            handler.send_header("content-type", "application/json")
+            handler.send_header("content-length", str(len(data)))
+            handler.end_headers()
+            handler.wfile.write(data)
+            context.event_queue.put(
+                ResponseHeadersEvent(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    request_id=request_id,
+                    seq=0,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            context.event_queue.put(
+                ResponseCompleteEvent(
+                    body=response_body,
+                    request_id=request_id,
+                    seq=1,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            return True
+
+        if request_path in _COPILOT_EMBEDDINGS_PATHS:
+            prepared_embeddings, error = copilot_provider.prepare_openai_embeddings_request(
+                snapshot=runtime_snapshot,
+                openai_payload=body,
+            )
+            if error is not None or prepared_embeddings is None:
+                return self._auth_error(context, error or "Copilot auth configuration missing")
+            request_bytes = json.dumps(prepared_embeddings.body).encode("utf-8")
+            upstream_req = urllib.request.Request(
+                prepared_embeddings.url,
+                data=request_bytes,
+                headers=prepared_embeddings.headers,
+                method="POST",
+            )
+            return self._relay_non_stream_upstream(context, upstream_req)
+
+        if request_path in _COPILOT_TOKEN_PATHS:
+            token, error = resolve_copilot_token(runtime_snapshot)
+            if error is not None:
+                return self._auth_error(context, error)
+            response_body = {"token": token}
+            data = json.dumps(response_body).encode("utf-8")
+            handler.send_response(200)
+            handler.send_header("content-type", "application/json")
+            handler.send_header("content-length", str(len(data)))
+            handler.end_headers()
+            handler.wfile.write(data)
+            context.event_queue.put(
+                ResponseHeadersEvent(
+                    status_code=200,
+                    headers={"content-type": "application/json"},
+                    request_id=request_id,
+                    seq=0,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            context.event_queue.put(
+                ResponseCompleteEvent(
+                    body=response_body,
+                    request_id=request_id,
+                    seq=1,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            return True
+
+        if request_path in _COPILOT_USAGE_PATHS:
+            prepared_usage, error = copilot_provider.prepare_usage_request(snapshot=runtime_snapshot)
+            if error is not None or prepared_usage is None:
+                return self._auth_error(context, error or "Copilot GitHub auth missing for /usage")
+            upstream_req = urllib.request.Request(
+                prepared_usage.url,
+                data=None,
+                headers=prepared_usage.headers,
+                method=prepared_usage.method,
+            )
+            return self._relay_non_stream_upstream(context, upstream_req)
+
+        if request_path == "/v1/models":
+            prepared_models, error = copilot_provider.prepare_models_request(snapshot=runtime_snapshot)
+            if error is not None or prepared_models is None:
+                return self._auth_error(context, error or "Copilot auth configuration missing")
+            upstream_req = urllib.request.Request(
+                prepared_models.url,
+                data=None,
+                headers=prepared_models.headers,
+                method="GET",
+            )
+            try:
+                ctx = ssl.create_default_context()
+                resp = urllib.request.urlopen(upstream_req, context=ctx, timeout=300)
+            except urllib.error.HTTPError as e:
+                return self._relay_http_error(context, e)
+            except Exception as e:  # pragma: no cover - defensive
+                return self._relay_proxy_error(context, e)
+            data = resp.read()
+            try:
+                copilot_models = json.loads(data)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                copilot_models = {}
+            anthropic_models = (
+                copilot_provider.translate_models_response(copilot_models)
+                if isinstance(copilot_models, dict)
+                else {"data": [], "has_more": False, "first_id": "", "last_id": ""}
+            )
+            output = json.dumps(anthropic_models).encode("utf-8")
+            handler.send_response(resp.status)
+            handler.send_header("content-type", "application/json")
+            handler.send_header("content-length", str(len(output)))
+            handler.end_headers()
+            handler.wfile.write(output)
+            context.event_queue.put(
+                ResponseHeadersEvent(
+                    status_code=resp.status,
+                    headers={"content-type": "application/json"},
+                    request_id=request_id,
+                    seq=0,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            context.event_queue.put(
+                ResponseCompleteEvent(
+                    body=anthropic_models,
+                    request_id=request_id,
+                    seq=1,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            return True
+
+        if request_path == "/models":
+            prepared_models, error = copilot_provider.prepare_models_request(snapshot=runtime_snapshot)
+            if error is not None or prepared_models is None:
+                return self._auth_error(context, error or "Copilot auth configuration missing")
+            upstream_req = urllib.request.Request(
+                prepared_models.url,
+                data=None,
+                headers=prepared_models.headers,
+                method="GET",
+            )
+            return self._relay_non_stream_upstream(context, upstream_req)
+
+        if request_path in _COPILOT_CHAT_PATHS:
+            prepared_openai, error = copilot_provider.prepare_openai_chat_request(
+                snapshot=runtime_snapshot,
+                openai_payload=body,
+            )
+            if error is not None or prepared_openai is None:
+                return self._auth_error(context, error or "Copilot auth configuration missing")
+            request_bytes = json.dumps(prepared_openai.body).encode("utf-8")
+            upstream_req = urllib.request.Request(
+                prepared_openai.url,
+                data=request_bytes,
+                headers=prepared_openai.headers,
+                method="POST",
+            )
+            try:
+                ctx = ssl.create_default_context()
+                resp = urllib.request.urlopen(upstream_req, context=ctx, timeout=300)
+            except urllib.error.HTTPError as e:
+                return self._relay_http_error(context, e)
+            except Exception as e:  # pragma: no cover - defensive
+                return self._relay_proxy_error(context, e)
+            if prepared_openai.stream:
+                handler.send_response(resp.status)
+                for k, v in resp.headers.items():
+                    if k.lower() != "transfer-encoding":
+                        handler.send_header(k, v)
+                handler.end_headers()
+                context.event_queue.put(
+                    ResponseHeadersEvent(
+                        status_code=resp.status,
+                        headers=context.safe_headers(resp.headers),
+                        request_id=request_id,
+                        seq=0,
+                        recv_ns=time.monotonic_ns(),
+                    )
+                )
+                self._stream_passthrough_response(context, resp)
+                return True
+            data = resp.read()
+            handler.send_response(resp.status)
+            for k, v in resp.headers.items():
+                if k.lower() != "transfer-encoding":
+                    handler.send_header(k, v)
+            handler.end_headers()
+            handler.wfile.write(data)
+            try:
+                parsed_body = json.loads(data)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                parsed_body = {}
+            context.event_queue.put(
+                ResponseHeadersEvent(
+                    status_code=resp.status,
+                    headers=context.safe_headers(resp.headers),
+                    request_id=request_id,
+                    seq=0,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            context.event_queue.put(
+                ResponseCompleteEvent(
+                    body=parsed_body,
+                    request_id=request_id,
+                    seq=1,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            return True
+
+        prepared, error = copilot_provider.prepare_messages_request(
+            snapshot=runtime_snapshot,
+            anthropic_payload=body,
+        )
+        if error is not None or prepared is None:
+            return self._auth_error(context, error or "Copilot auth configuration missing")
+
+        request_bytes = json.dumps(prepared.body).encode("utf-8")
+        upstream_req = urllib.request.Request(
+            prepared.url,
+            data=request_bytes,
+            headers=prepared.headers,
+            method="POST",
+        )
+        try:
+            ctx = ssl.create_default_context()
+            resp = urllib.request.urlopen(upstream_req, context=ctx, timeout=300)
+        except urllib.error.HTTPError as e:
+            return self._relay_anthropic_http_error(context, e)
+        except Exception as e:  # pragma: no cover - defensive
+            return self._relay_proxy_error(context, e)
+
+        if prepared.stream:
+            handler.send_response(resp.status)
+            handler.send_header("content-type", "text/event-stream")
+            handler.send_header("cache-control", "no-cache")
+            handler.end_headers()
+            context.event_queue.put(
+                ResponseHeadersEvent(
+                    status_code=resp.status,
+                    headers={"content-type": "text/event-stream"},
+                    request_id=request_id,
+                    seq=0,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+            self._stream_copilot_response(context, resp)
+            return True
+
+        upstream_data = resp.read()
+        try:
+            openai_body = json.loads(upstream_data)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            openai_body = {}
+        anthropic_body = copilot_provider.translate_non_stream_response(openai_body)
+        output_data = json.dumps(anthropic_body).encode("utf-8")
+        handler.send_response(resp.status)
+        handler.send_header("content-type", "application/json")
+        handler.send_header("content-length", str(len(output_data)))
+        handler.end_headers()
+        handler.wfile.write(output_data)
+        context.event_queue.put(
+            ResponseHeadersEvent(
+                status_code=resp.status,
+                headers={"content-type": "application/json"},
+                request_id=request_id,
+                seq=0,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.event_queue.put(
+            ResponseCompleteEvent(
+                body=anthropic_body,
+                request_id=request_id,
+                seq=1,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        return True
+
+    def _auth_error(self, context: ProxyRequestContext, message: str) -> bool:
+        context.event_queue.put(
+            ErrorEvent(
+                code=401,
+                reason=message,
+                request_id=context.request_id,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.handler.send_response(401)
+        context.handler.send_header("content-type", "application/json")
+        context.handler.end_headers()
+        context.handler.wfile.write(
+            json.dumps(
+                {
+                    "type": "error",
+                    "error": {
+                        "type": "authentication_error",
+                        "message": message,
+                    },
+                }
+            ).encode("utf-8")
+        )
+        return True
+
+    def _relay_non_stream_upstream(self, context: ProxyRequestContext, upstream_req: urllib.request.Request) -> bool:
+        try:
+            ctx = ssl.create_default_context()
+            resp = urllib.request.urlopen(upstream_req, context=ctx, timeout=300)
+        except urllib.error.HTTPError as e:
+            return self._relay_http_error(context, e)
+        except Exception as e:  # pragma: no cover - defensive
+            return self._relay_proxy_error(context, e)
+        data = resp.read()
+        context.handler.send_response(resp.status)
+        for k, v in resp.headers.items():
+            if k.lower() != "transfer-encoding":
+                context.handler.send_header(k, v)
+        context.handler.end_headers()
+        context.handler.wfile.write(data)
+        try:
+            parsed_body = json.loads(data)
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            parsed_body = {}
+        context.event_queue.put(
+            ResponseHeadersEvent(
+                status_code=resp.status,
+                headers=context.safe_headers(resp.headers),
+                request_id=context.request_id,
+                seq=0,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.event_queue.put(
+            ResponseCompleteEvent(
+                body=parsed_body,
+                request_id=context.request_id,
+                seq=1,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        return True
+
+    def _relay_http_error(self, context: ProxyRequestContext, error: urllib.error.HTTPError) -> bool:
+        context.event_queue.put(
+            ErrorEvent(
+                code=error.code,
+                reason=error.reason,
+                request_id=context.request_id,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.handler.send_response(error.code)
+        for k, v in error.headers.items():
+            if k.lower() != "transfer-encoding":
+                context.handler.send_header(k, v)
+        context.handler.end_headers()
+        context.handler.wfile.write(error.read())
+        return True
+
+    def _relay_anthropic_http_error(self, context: ProxyRequestContext, error: urllib.error.HTTPError) -> bool:
+        error_bytes = error.read()
+        try:
+            openai_error_body = json.loads(error_bytes.decode("utf-8", errors="replace"))
+        except json.JSONDecodeError:
+            openai_error_body = {}
+        anthropic_error = copilot_provider.translate_error_response(
+            openai_error_body if isinstance(openai_error_body, dict) else {},
+            fallback_message=f"Copilot upstream HTTP {error.code}",
+        )
+        response_data = json.dumps(anthropic_error).encode("utf-8")
+        context.event_queue.put(
+            ErrorEvent(
+                code=error.code,
+                reason=error.reason,
+                request_id=context.request_id,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.handler.send_response(error.code)
+        context.handler.send_header("content-type", "application/json")
+        context.handler.send_header("content-length", str(len(response_data)))
+        context.handler.end_headers()
+        context.handler.wfile.write(response_data)
+        return True
+
+    def _relay_proxy_error(self, context: ProxyRequestContext, error: Exception) -> bool:
+        context.event_queue.put(
+            ProxyErrorEvent(
+                error=str(error),
+                request_id=context.request_id,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+        context.handler.send_response(502)
+        context.handler.end_headers()
+        return True
+
+    def _stream_copilot_response(self, context: ProxyRequestContext, resp) -> None:
+        assembler = ResponseAssembler()
+        seq = 0
+        stream_state = copilot_provider.stream_state()
+        stream_error_event: dict | None = None
+        try:
+            for raw_line in resp:
+                line = raw_line.decode("utf-8", errors="replace").rstrip("\r\n")
+                if not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                if not payload:
+                    continue
+                try:
+                    chunk = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(chunk, dict):
+                    continue
+                translated_events = copilot_provider.translate_stream_chunk(
+                    chunk_payload=chunk,
+                    state=stream_state,
+                )
+                for event in translated_events:
+                    event_type = str(event.get("type", ""))
+                    raw = b"data: " + json.dumps(event).encode("utf-8") + b"\n\n"
+                    context.handler.wfile.write(raw)
+                    context.handler.wfile.flush()
+                    if event_type:
+                        assembler.on_event(event_type, event)
+                        try:
+                            sse = parse_sse_event(event_type, event)
+                        except ValueError:
+                            sse = None
+                        payload = sse_progress_payload(sse) if sse is not None else None
+                        if payload is not None:
+                            seq += 1
+                            context.event_queue.put(
+                                ResponseProgressEvent(
+                                    request_id=context.request_id,
+                                    seq=seq,
+                                    recv_ns=time.monotonic_ns(),
+                                    **payload,
+                                )
+                            )
+        except Exception:
+            stream_error_event = copilot_provider.stream_error_event()
+        finally:
+            if stream_error_event is not None:
+                error_type = str(stream_error_event.get("type", "error"))
+                error_raw = b"data: " + json.dumps(stream_error_event).encode("utf-8") + b"\n\n"
+                context.handler.wfile.write(error_raw)
+                context.handler.wfile.flush()
+                assembler.on_event(error_type, stream_error_event)
+            context.handler.wfile.write(b"data: [DONE]\n\n")
+            context.handler.wfile.flush()
+
+        assembler.on_done()
+        if assembler.result is not None:
+            seq += 1
+            context.event_queue.put(
+                ResponseCompleteEvent(
+                    body=assembler.result,
+                    request_id=context.request_id,
+                    seq=seq,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+        seq += 1
+        context.event_queue.put(
+            ResponseDoneEvent(
+                request_id=context.request_id,
+                seq=seq,
+                recv_ns=time.monotonic_ns(),
+            )
+        )
+
+    def _stream_passthrough_response(self, context: ProxyRequestContext, resp) -> None:
+        try:
+            for raw_line in resp:
+                context.handler.wfile.write(raw_line)
+                context.handler.wfile.flush()
+        finally:
+            context.event_queue.put(
+                ResponseDoneEvent(
+                    request_id=context.request_id,
+                    seq=1,
+                    recv_ns=time.monotonic_ns(),
+                )
+            )
+
+
+def create_plugin() -> ProxyProviderPlugin:
+    # // [LAW:locality-or-seam] Factory is the seam used by generic registry discovery.
+    return CopilotProxyPlugin()

--- a/src/cc_dump/proxies/copilot/provider.py
+++ b/src/cc_dump/proxies/copilot/provider.py
@@ -1,0 +1,306 @@
+"""Copilot provider adapter for Anthropic-compatible client traffic."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+from typing import Any
+
+from cc_dump.core.token_counter import count_tokens
+from cc_dump.proxies.copilot.api_config import (
+    CopilotAuthConfig,
+    build_copilot_headers,
+    resolve_copilot_base_url,
+)
+from cc_dump.proxies.copilot.token_manager import (
+    GITHUB_API_BASE_URL,
+    build_github_headers,
+    resolve_copilot_token,
+)
+from cc_dump.proxies.copilot.translation import (
+    AnthropicStreamState,
+    translate_chunk_to_anthropic_events,
+    translate_error_to_anthropic,
+    translate_models_to_anthropic,
+    translate_stream_error_to_anthropic,
+    translate_to_anthropic,
+    translate_to_openai,
+)
+from cc_dump.proxies.runtime import ProxyRuntimeSnapshot
+
+
+@dataclass(frozen=True)
+class PreparedCopilotRequest:
+    url: str
+    headers: dict[str, str]
+    body: dict[str, Any]
+    stream: bool
+
+
+@dataclass(frozen=True)
+class PreparedCopilotModelsRequest:
+    url: str
+    headers: dict[str, str]
+
+
+@dataclass(frozen=True)
+class PreparedCopilotSimpleRequest:
+    url: str
+    headers: dict[str, str]
+    method: str = "GET"
+
+
+def _contains_image_content(messages: object) -> bool:
+    if not isinstance(messages, list):
+        return False
+    stack = list(messages)
+    while stack:
+        item = stack.pop()
+        if isinstance(item, dict):
+            if item.get("type") == "image":
+                return True
+            stack.extend(item.values())
+        elif isinstance(item, list):
+            stack.extend(item)
+    return False
+
+
+def _is_agent_call(messages: object) -> bool:
+    if not isinstance(messages, list):
+        return False
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role", ""))
+        if role in {"assistant", "tool"}:
+            return True
+    return False
+
+
+def prepare_messages_request(
+    *,
+    snapshot: ProxyRuntimeSnapshot,
+    anthropic_payload: dict[str, Any],
+) -> tuple[PreparedCopilotRequest | None, str | None]:
+    openai_payload = translate_to_openai(anthropic_payload)
+    openai_payload["stream"] = bool(anthropic_payload.get("stream", False))
+    token, error = resolve_copilot_token(snapshot)
+    if error is not None:
+        return None, error
+
+    auth = CopilotAuthConfig(
+        token=token,
+        account_type=snapshot.get_text("proxy_copilot_account_type", "individual"),
+        base_url=snapshot.get_text("proxy_copilot_base_url"),
+        vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+    )
+    base_url = resolve_copilot_base_url(auth)
+    vision = _contains_image_content(anthropic_payload.get("messages"))
+    is_agent = _is_agent_call(openai_payload.get("messages"))
+    headers = build_copilot_headers(
+        config=auth,
+        vision=vision,
+        agent_initiator=is_agent,
+    )
+    headers["accept"] = "text/event-stream" if bool(openai_payload.get("stream")) else "application/json"
+    return (
+        PreparedCopilotRequest(
+            url=f"{base_url}/chat/completions",
+            headers=headers,
+            body=openai_payload,
+            stream=bool(openai_payload.get("stream")),
+        ),
+        None,
+    )
+
+
+def prepare_openai_chat_request(
+    *,
+    snapshot: ProxyRuntimeSnapshot,
+    openai_payload: dict[str, Any],
+) -> tuple[PreparedCopilotRequest | None, str | None]:
+    token, error = resolve_copilot_token(snapshot)
+    if error is not None:
+        return None, error
+    auth = CopilotAuthConfig(
+        token=token,
+        account_type=snapshot.get_text("proxy_copilot_account_type", "individual"),
+        base_url=snapshot.get_text("proxy_copilot_base_url"),
+        vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+    )
+    base_url = resolve_copilot_base_url(auth)
+    messages = openai_payload.get("messages", [])
+    vision = _contains_image_content(messages)
+    is_agent = _is_agent_call(messages)
+    headers = build_copilot_headers(
+        config=auth,
+        vision=vision,
+        agent_initiator=is_agent,
+    )
+    stream = bool(openai_payload.get("stream"))
+    headers["accept"] = "text/event-stream" if stream else "application/json"
+    return (
+        PreparedCopilotRequest(
+            url=f"{base_url}/chat/completions",
+            headers=headers,
+            body=openai_payload,
+            stream=stream,
+        ),
+        None,
+    )
+
+
+def prepare_openai_embeddings_request(
+    *,
+    snapshot: ProxyRuntimeSnapshot,
+    openai_payload: dict[str, Any],
+) -> tuple[PreparedCopilotRequest | None, str | None]:
+    token, error = resolve_copilot_token(snapshot)
+    if error is not None:
+        return None, error
+    auth = CopilotAuthConfig(
+        token=token,
+        account_type=snapshot.get_text("proxy_copilot_account_type", "individual"),
+        base_url=snapshot.get_text("proxy_copilot_base_url"),
+        vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+    )
+    base_url = resolve_copilot_base_url(auth)
+    headers = build_copilot_headers(
+        config=auth,
+        vision=False,
+        agent_initiator=False,
+    )
+    headers["accept"] = "application/json"
+    return (
+        PreparedCopilotRequest(
+            url=f"{base_url}/embeddings",
+            headers=headers,
+            body=openai_payload,
+            stream=False,
+        ),
+        None,
+    )
+
+
+def prepare_models_request(
+    *,
+    snapshot: ProxyRuntimeSnapshot,
+) -> tuple[PreparedCopilotModelsRequest | None, str | None]:
+    token, error = resolve_copilot_token(snapshot)
+    if error is not None:
+        return None, error
+    auth = CopilotAuthConfig(
+        token=token,
+        account_type=snapshot.get_text("proxy_copilot_account_type", "individual"),
+        base_url=snapshot.get_text("proxy_copilot_base_url"),
+        vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+    )
+    base_url = resolve_copilot_base_url(auth)
+    headers = build_copilot_headers(config=auth, vision=False, agent_initiator=False)
+    headers["accept"] = "application/json"
+    return (
+        PreparedCopilotModelsRequest(
+            url=f"{base_url}/models",
+            headers=headers,
+        ),
+        None,
+    )
+
+
+def prepare_usage_request(
+    *,
+    snapshot: ProxyRuntimeSnapshot,
+) -> tuple[PreparedCopilotSimpleRequest | None, str | None]:
+    github_token = snapshot.get_text("proxy_copilot_github_token")
+    if not github_token:
+        return None, "Missing proxy_copilot_github_token for /usage"
+    headers = build_github_headers(
+        github_token,
+        vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+    )
+    return (
+        PreparedCopilotSimpleRequest(
+            url=f"{GITHUB_API_BASE_URL}/copilot_internal/user",
+            headers=headers,
+            method="GET",
+        ),
+        None,
+    )
+
+
+def translate_non_stream_response(
+    openai_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return translate_to_anthropic(openai_payload)
+
+
+def translate_models_response(
+    copilot_models_payload: dict[str, Any],
+) -> dict[str, Any]:
+    return translate_models_to_anthropic(copilot_models_payload)
+
+
+def translate_error_response(
+    upstream_error_payload: dict[str, Any],
+    *,
+    fallback_message: str,
+) -> dict[str, Any]:
+    return translate_error_to_anthropic(
+        upstream_error_payload,
+        fallback_message=fallback_message,
+    )
+
+
+def stream_error_event() -> dict[str, Any]:
+    return translate_stream_error_to_anthropic()
+
+
+def count_tokens_for_messages(anthropic_payload: dict[str, Any]) -> int:
+    """Approximate /v1/messages/count_tokens for Copilot-backed requests.
+
+    Mirrors the high-level heuristic policy from the reference implementation.
+    """
+    try:
+        openai_payload = translate_to_openai(anthropic_payload)
+        payload_str = json.dumps(openai_payload, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
+        estimated = count_tokens(payload_str)
+
+        tools = anthropic_payload.get("tools", [])
+        if isinstance(tools, list) and tools:
+            anthropic_beta = str(anthropic_payload.get("_anthropic_beta", "") or "")
+            mcp_tool_exists = anthropic_beta.startswith("claude-code") and any(
+                isinstance(tool, dict)
+                and isinstance(tool.get("name"), str)
+                and tool.get("name", "").startswith("mcp__")
+                for tool in tools
+            )
+            if not mcp_tool_exists:
+                model = str(anthropic_payload.get("model", "")).lower()
+                if model.startswith("claude"):
+                    estimated += 346
+                elif model.startswith("grok"):
+                    estimated += 480
+
+        model = str(anthropic_payload.get("model", "")).lower()
+        multiplier = 1.0
+        if model.startswith("claude"):
+            multiplier = 1.15
+        elif model.startswith("grok"):
+            multiplier = 1.03
+        final_count = int(round(max(1, estimated * multiplier)))
+        return final_count
+    except Exception:
+        # // [LAW:single-enforcer] Token-count endpoint owns fallback contract for malformed payloads.
+        return 1
+
+
+def stream_state() -> AnthropicStreamState:
+    return AnthropicStreamState()
+
+
+def translate_stream_chunk(
+    *,
+    chunk_payload: dict[str, Any],
+    state: AnthropicStreamState,
+) -> list[dict[str, Any]]:
+    return translate_chunk_to_anthropic_events(chunk_payload, state)

--- a/src/cc_dump/proxies/copilot/rate_limit.py
+++ b/src/cc_dump/proxies/copilot/rate_limit.py
@@ -1,0 +1,40 @@
+"""Simple per-process rate limiter for Copilot upstream requests."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+
+class CopilotRateLimiter:
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._last_request_mono = 0.0
+
+    def gate(
+        self,
+        *,
+        min_interval_seconds: int,
+        wait_on_limit: bool,
+    ) -> tuple[bool, float]:
+        interval = max(0.0, float(min_interval_seconds))
+        if interval <= 0:
+            return True, 0.0
+
+        with self._lock:
+            now = time.monotonic()
+            elapsed = now - self._last_request_mono
+            remaining = interval - elapsed
+            if remaining <= 0:
+                self._last_request_mono = now
+                return True, 0.0
+            if not wait_on_limit:
+                return False, remaining
+
+        time.sleep(max(0.0, remaining))
+        with self._lock:
+            self._last_request_mono = time.monotonic()
+        return True, remaining
+
+
+copilot_rate_limiter = CopilotRateLimiter()

--- a/src/cc_dump/proxies/copilot/token_manager.py
+++ b/src/cc_dump/proxies/copilot/token_manager.py
@@ -1,0 +1,99 @@
+"""Copilot token resolver with GitHub-token refresh fallback."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import threading
+import time
+import urllib.request
+import urllib.error
+
+from cc_dump.proxies.runtime import ProxyRuntimeSnapshot
+
+
+COPILOT_VERSION = "0.26.7"
+EDITOR_PLUGIN_VERSION = f"copilot-chat/{COPILOT_VERSION}"
+USER_AGENT = f"GitHubCopilotChat/{COPILOT_VERSION}"
+API_VERSION = "2025-04-01"
+GITHUB_API_BASE_URL = "https://api.github.com"
+
+
+@dataclass
+class _CachedCopilotToken:
+    token: str
+    expires_at_unix: int
+    refresh_at_unix: int
+
+
+_CACHE_LOCK = threading.Lock()
+_CACHE_BY_GITHUB_TOKEN: dict[str, _CachedCopilotToken] = {}
+
+
+def build_github_headers(github_token: str, *, vscode_version: str = "1.99.0") -> dict[str, str]:
+    return {
+        "content-type": "application/json",
+        "accept": "application/json",
+        "authorization": f"token {github_token}",
+        "editor-version": f"vscode/{vscode_version}",
+        "editor-plugin-version": EDITOR_PLUGIN_VERSION,
+        "user-agent": USER_AGENT,
+        "x-github-api-version": API_VERSION,
+        "x-vscode-user-agent-library-version": "electron-fetch",
+    }
+
+
+def _fetch_copilot_token(github_token: str, *, vscode_version: str) -> _CachedCopilotToken:
+    request = urllib.request.Request(
+        f"{GITHUB_API_BASE_URL}/copilot_internal/v2/token",
+        headers=build_github_headers(github_token, vscode_version=vscode_version),
+        method="GET",
+    )
+    response = urllib.request.urlopen(request, timeout=30)
+    payload = json.loads(response.read().decode("utf-8"))
+    token = str(payload.get("token", "") or "").strip()
+    expires_at = int(payload.get("expires_at", 0) or 0)
+    refresh_in = int(payload.get("refresh_in", 0) or 0)
+    now = int(time.time())
+    if expires_at <= 0:
+        expires_at = now + max(300, refresh_in)
+    refresh_at = now + max(30, refresh_in - 60)
+    return _CachedCopilotToken(
+        token=token,
+        expires_at_unix=expires_at,
+        refresh_at_unix=refresh_at,
+    )
+
+
+def resolve_copilot_token(snapshot: ProxyRuntimeSnapshot) -> tuple[str, str | None]:
+    """Resolve active Copilot bearer token from settings or GitHub fallback."""
+    explicit = snapshot.get_text("proxy_copilot_token")
+    if explicit:
+        return explicit, None
+
+    github_token = snapshot.get_text("proxy_copilot_github_token")
+    if not github_token:
+        return "", "Missing proxy_copilot_token and proxy_copilot_github_token"
+
+    now = int(time.time())
+    with _CACHE_LOCK:
+        cached = _CACHE_BY_GITHUB_TOKEN.get(github_token)
+        if cached is not None and cached.token and now < cached.refresh_at_unix:
+            return cached.token, None
+
+    try:
+        refreshed = _fetch_copilot_token(
+            github_token,
+            vscode_version=snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") or "1.99.0",
+        )
+    except urllib.error.HTTPError as e:
+        return "", f"Failed to fetch Copilot token from GitHub: HTTP {e.code}"
+    except Exception as e:  # pragma: no cover - defensive
+        return "", f"Failed to fetch Copilot token from GitHub: {e}"
+
+    if not refreshed.token:
+        return "", "GitHub Copilot token endpoint returned an empty token"
+
+    with _CACHE_LOCK:
+        _CACHE_BY_GITHUB_TOKEN[github_token] = refreshed
+    return refreshed.token, None

--- a/src/cc_dump/proxies/copilot/translation.py
+++ b/src/cc_dump/proxies/copilot/translation.py
@@ -1,0 +1,586 @@
+"""Anthropic <-> OpenAI payload translation for Copilot upstreams.
+
+General structure ported from the reference copilot-api project.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+import json
+from typing import Any
+
+
+def map_openai_stop_reason_to_anthropic(reason: str | None) -> str:
+    mapping = {
+        "stop": "end_turn",
+        "length": "max_tokens",
+        "tool_calls": "tool_use",
+        "content_filter": "stop_sequence",
+    }
+    return mapping.get(str(reason or ""), "end_turn")
+
+
+def translate_model_name(model: str) -> str:
+    model = str(model or "")
+    if model.startswith("claude-sonnet-4-"):
+        return "claude-sonnet-4"
+    if model.startswith("claude-opus-4-"):
+        return "claude-opus-4"
+    return model
+
+
+def _handle_system_prompt(system: object) -> list[dict[str, Any]]:
+    if isinstance(system, str):
+        return [{"role": "system", "content": system}]
+    if isinstance(system, list):
+        text_parts = [
+            str(block.get("text", ""))
+            for block in system
+            if isinstance(block, dict) and isinstance(block.get("text"), str)
+        ]
+        if text_parts:
+            return [{"role": "system", "content": "\n\n".join(text_parts)}]
+    return []
+
+
+def _map_content(content: object) -> object:
+    if isinstance(content, str):
+        return content
+    if not isinstance(content, list):
+        return None
+
+    has_image = any(isinstance(block, dict) and block.get("type") == "image" for block in content)
+    if not has_image:
+        text_parts: list[str] = []
+        for block in content:
+            if not isinstance(block, dict):
+                continue
+            block_type = str(block.get("type", ""))
+            if block_type == "text" and isinstance(block.get("text"), str):
+                text_parts.append(str(block.get("text")))
+            elif block_type == "thinking" and isinstance(block.get("thinking"), str):
+                text_parts.append(str(block.get("thinking")))
+        return "\n\n".join(text_parts)
+
+    mapped_parts: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        block_type = str(block.get("type", ""))
+        if block_type == "text" and isinstance(block.get("text"), str):
+            mapped_parts.append({"type": "text", "text": block["text"]})
+        elif block_type == "thinking" and isinstance(block.get("thinking"), str):
+            mapped_parts.append({"type": "text", "text": block["thinking"]})
+        elif block_type == "image":
+            source = block.get("source", {})
+            if not isinstance(source, dict):
+                continue
+            media_type = str(source.get("media_type", "image/png"))
+            data = str(source.get("data", ""))
+            mapped_parts.append(
+                {
+                    "type": "image_url",
+                    "image_url": {"url": f"data:{media_type};base64,{data}"},
+                }
+            )
+    return mapped_parts
+
+
+def _handle_user_message(message: dict[str, Any]) -> list[dict[str, Any]]:
+    content = message.get("content", "")
+    if not isinstance(content, list):
+        return [{"role": "user", "content": _map_content(content)}]
+
+    tool_results: list[dict[str, Any]] = []
+    other_blocks: list[dict[str, Any]] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") == "tool_result":
+            tool_results.append(block)
+        else:
+            other_blocks.append(block)
+
+    messages: list[dict[str, Any]] = []
+    for block in tool_results:
+        messages.append(
+            {
+                "role": "tool",
+                "tool_call_id": str(block.get("tool_use_id", "")),
+                "content": _map_content(block.get("content", "")),
+            }
+        )
+    if other_blocks:
+        messages.append({"role": "user", "content": _map_content(other_blocks)})
+    return messages
+
+
+def _handle_assistant_message(message: dict[str, Any]) -> list[dict[str, Any]]:
+    content = message.get("content", "")
+    if not isinstance(content, list):
+        return [{"role": "assistant", "content": _map_content(content)}]
+
+    tool_use_blocks = [
+        block
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "tool_use"
+    ]
+    text_blocks = [
+        str(block.get("text", ""))
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "text"
+    ]
+    thinking_blocks = [
+        str(block.get("thinking", ""))
+        for block in content
+        if isinstance(block, dict) and block.get("type") == "thinking"
+    ]
+    all_text = "\n\n".join([*text_blocks, *thinking_blocks]).strip()
+
+    if tool_use_blocks:
+        tool_calls: list[dict[str, Any]] = []
+        for block in tool_use_blocks:
+            tool_calls.append(
+                {
+                    "id": str(block.get("id", "")),
+                    "type": "function",
+                    "function": {
+                        "name": str(block.get("name", "")),
+                        "arguments": json.dumps(block.get("input", {}), ensure_ascii=False),
+                    },
+                }
+            )
+        return [{"role": "assistant", "content": all_text or None, "tool_calls": tool_calls}]
+    return [{"role": "assistant", "content": _map_content(content)}]
+
+
+def _translate_anthropic_messages_to_openai(
+    anthropic_messages: object,
+    system: object,
+) -> list[dict[str, Any]]:
+    output = _handle_system_prompt(system)
+    if not isinstance(anthropic_messages, list):
+        return output
+
+    for message in anthropic_messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role", ""))
+        if role == "user":
+            output.extend(_handle_user_message(message))
+        elif role == "assistant":
+            output.extend(_handle_assistant_message(message))
+    return output
+
+
+def _translate_tools(anthropic_tools: object) -> list[dict[str, Any]] | None:
+    if not isinstance(anthropic_tools, list):
+        return None
+    translated: list[dict[str, Any]] = []
+    for tool in anthropic_tools:
+        if not isinstance(tool, dict):
+            continue
+        translated.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": str(tool.get("name", "")),
+                    "description": str(tool.get("description", "")),
+                    "parameters": tool.get("input_schema", {}),
+                },
+            }
+        )
+    return translated or None
+
+
+def _translate_tool_choice(choice: object) -> object:
+    if not isinstance(choice, dict):
+        return None
+    choice_type = str(choice.get("type", ""))
+    if choice_type == "auto":
+        return "auto"
+    if choice_type == "any":
+        return "required"
+    if choice_type == "none":
+        return "none"
+    if choice_type == "tool":
+        tool_name = str(choice.get("name", ""))
+        if tool_name:
+            return {"type": "function", "function": {"name": tool_name}}
+    return None
+
+
+def _drop_none_fields(payload: dict[str, Any]) -> dict[str, Any]:
+    return {k: v for k, v in payload.items() if v is not None}
+
+
+def translate_to_openai(payload: dict[str, Any]) -> dict[str, Any]:
+    mapped = {
+        "model": translate_model_name(str(payload.get("model", ""))),
+        "messages": _translate_anthropic_messages_to_openai(
+            payload.get("messages", []),
+            payload.get("system"),
+        ),
+        "max_tokens": payload.get("max_tokens"),
+        "stop": payload.get("stop_sequences"),
+        "stream": payload.get("stream"),
+        "temperature": payload.get("temperature"),
+        "top_p": payload.get("top_p"),
+        "user": payload.get("metadata", {}).get("user_id")
+        if isinstance(payload.get("metadata"), dict)
+        else None,
+        "tools": _translate_tools(payload.get("tools")),
+        "tool_choice": _translate_tool_choice(payload.get("tool_choice")),
+    }
+    return _drop_none_fields(mapped)
+
+
+def _text_blocks_from_openai_content(content: object) -> list[dict[str, str]]:
+    if isinstance(content, str):
+        return [{"type": "text", "text": content}] if content else []
+    if not isinstance(content, list):
+        return []
+    blocks: list[dict[str, str]] = []
+    for part in content:
+        if isinstance(part, dict) and part.get("type") == "text" and isinstance(part.get("text"), str):
+            blocks.append({"type": "text", "text": str(part["text"])})
+    return blocks
+
+
+def _tool_use_blocks_from_openai(tool_calls: object) -> list[dict[str, Any]]:
+    if not isinstance(tool_calls, list):
+        return []
+    blocks: list[dict[str, Any]] = []
+    for tool_call in tool_calls:
+        if not isinstance(tool_call, dict):
+            continue
+        fn = tool_call.get("function", {})
+        if not isinstance(fn, dict):
+            fn = {}
+        raw_args = fn.get("arguments", "{}")
+        parsed_args: object
+        try:
+            parsed_args = json.loads(str(raw_args or "{}"))
+        except json.JSONDecodeError:
+            parsed_args = {}
+        if not isinstance(parsed_args, dict):
+            parsed_args = {}
+        blocks.append(
+            {
+                "type": "tool_use",
+                "id": str(tool_call.get("id", "")),
+                "name": str(fn.get("name", "")),
+                "input": parsed_args,
+            }
+        )
+    return blocks
+
+
+def translate_to_anthropic(response: dict[str, Any]) -> dict[str, Any]:
+    choices = response.get("choices", [])
+    if not isinstance(choices, list):
+        choices = []
+
+    all_text_blocks: list[dict[str, Any]] = []
+    all_tool_use_blocks: list[dict[str, Any]] = []
+    stop_reason = "end_turn"
+    for idx, choice in enumerate(choices):
+        if not isinstance(choice, dict):
+            continue
+        message = choice.get("message", {})
+        if not isinstance(message, dict):
+            message = {}
+        all_text_blocks.extend(_text_blocks_from_openai_content(message.get("content")))
+        all_tool_use_blocks.extend(_tool_use_blocks_from_openai(message.get("tool_calls")))
+        current_finish = map_openai_stop_reason_to_anthropic(str(choice.get("finish_reason", "")))
+        if idx == 0 or current_finish == "tool_use":
+            stop_reason = current_finish
+
+    usage = response.get("usage", {})
+    if not isinstance(usage, dict):
+        usage = {}
+    prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+    completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+    details = usage.get("prompt_tokens_details", {})
+    if not isinstance(details, dict):
+        details = {}
+    cached_tokens = int(details.get("cached_tokens", 0) or 0)
+
+    usage_out = {
+        "input_tokens": max(0, prompt_tokens - cached_tokens),
+        "output_tokens": completion_tokens,
+    }
+    if cached_tokens:
+        usage_out["cache_read_input_tokens"] = cached_tokens
+
+    return {
+        "id": str(response.get("id", "")),
+        "type": "message",
+        "role": "assistant",
+        "model": str(response.get("model", "")),
+        "content": [*all_text_blocks, *all_tool_use_blocks],
+        "stop_reason": stop_reason,
+        "stop_sequence": None,
+        "usage": usage_out,
+    }
+
+
+def translate_models_to_anthropic(copilot_models: dict[str, Any]) -> dict[str, Any]:
+    raw_data = copilot_models.get("data", [])
+    if not isinstance(raw_data, list):
+        raw_data = []
+
+    translated_data: list[dict[str, Any]] = []
+    for model in raw_data:
+        if not isinstance(model, dict):
+            continue
+        model_id = str(model.get("id", "")).strip()
+        if not model_id:
+            continue
+        display_name = str(model.get("name", "")).strip() or model_id
+        translated_data.append(
+            {
+                "type": "model",
+                "id": model_id,
+                "display_name": display_name,
+                "created_at": "1970-01-01T00:00:00Z",
+            }
+        )
+
+    first_id = translated_data[0]["id"] if translated_data else ""
+    last_id = translated_data[-1]["id"] if translated_data else ""
+    return {
+        "data": translated_data,
+        "has_more": False,
+        "first_id": first_id,
+        "last_id": last_id,
+    }
+
+
+def translate_error_to_anthropic(
+    error_payload: dict[str, Any],
+    *,
+    fallback_message: str = "Upstream provider error",
+) -> dict[str, Any]:
+    error = error_payload.get("error", {})
+    if not isinstance(error, dict):
+        error = {}
+    message = str(error.get("message", "") or "").strip() or fallback_message
+    raw_type = str(error.get("type", "") or "").strip()
+    mapped_type = raw_type or "api_error"
+    return {
+        "type": "error",
+        "error": {
+            "type": mapped_type,
+            "message": message,
+        },
+    }
+
+
+def translate_stream_error_to_anthropic() -> dict[str, Any]:
+    return {
+        "type": "error",
+        "error": {
+            "type": "api_error",
+            "message": "An unexpected error occurred during streaming.",
+        },
+    }
+
+
+@dataclass
+class ToolCallState:
+    id: str
+    name: str
+    anthropic_block_index: int
+
+
+@dataclass
+class AnthropicStreamState:
+    message_start_sent: bool = False
+    content_block_index: int = 0
+    content_block_open: bool = False
+    tool_calls: dict[int, ToolCallState] = field(default_factory=dict)
+
+
+def _is_tool_block_open(state: AnthropicStreamState) -> bool:
+    if not state.content_block_open:
+        return False
+    return any(
+        tc.anthropic_block_index == state.content_block_index
+        for tc in state.tool_calls.values()
+    )
+
+
+def _usage_from_chunk(chunk: dict[str, Any]) -> tuple[int, int, int]:
+    usage = chunk.get("usage", {})
+    if not isinstance(usage, dict):
+        usage = {}
+    details = usage.get("prompt_tokens_details", {})
+    if not isinstance(details, dict):
+        details = {}
+    prompt_tokens = int(usage.get("prompt_tokens", 0) or 0)
+    completion_tokens = int(usage.get("completion_tokens", 0) or 0)
+    cached_tokens = int(details.get("cached_tokens", 0) or 0)
+    return prompt_tokens, completion_tokens, cached_tokens
+
+
+def translate_chunk_to_anthropic_events(
+    chunk: dict[str, Any],
+    state: AnthropicStreamState,
+) -> list[dict[str, Any]]:
+    events: list[dict[str, Any]] = []
+    choices = chunk.get("choices", [])
+    if not isinstance(choices, list) or not choices:
+        return events
+
+    choice = choices[0] if isinstance(choices[0], dict) else {}
+    delta = choice.get("delta", {})
+    if not isinstance(delta, dict):
+        delta = {}
+
+    prompt_tokens, completion_tokens, cached_tokens = _usage_from_chunk(chunk)
+
+    if not state.message_start_sent:
+        usage = {
+            "input_tokens": max(0, prompt_tokens - cached_tokens),
+            "output_tokens": 0,
+        }
+        if cached_tokens:
+            usage["cache_read_input_tokens"] = cached_tokens
+        events.append(
+            {
+                "type": "message_start",
+                "message": {
+                    "id": str(chunk.get("id", "")),
+                    "type": "message",
+                    "role": "assistant",
+                    "content": [],
+                    "model": str(chunk.get("model", "")),
+                    "stop_reason": None,
+                    "stop_sequence": None,
+                    "usage": usage,
+                },
+            }
+        )
+        state.message_start_sent = True
+
+    content_delta = delta.get("content")
+    if isinstance(content_delta, str) and content_delta:
+        if _is_tool_block_open(state):
+            events.append(
+                {
+                    "type": "content_block_stop",
+                    "index": state.content_block_index,
+                }
+            )
+            state.content_block_index += 1
+            state.content_block_open = False
+
+        if not state.content_block_open:
+            events.append(
+                {
+                    "type": "content_block_start",
+                    "index": state.content_block_index,
+                    "content_block": {"type": "text", "text": ""},
+                }
+            )
+            state.content_block_open = True
+
+        events.append(
+            {
+                "type": "content_block_delta",
+                "index": state.content_block_index,
+                "delta": {"type": "text_delta", "text": content_delta},
+            }
+        )
+
+    tool_calls = delta.get("tool_calls", [])
+    if isinstance(tool_calls, list):
+        for raw_tool_call in tool_calls:
+            if not isinstance(raw_tool_call, dict):
+                continue
+            raw_index = raw_tool_call.get("index", 0)
+            try:
+                tool_index = int(raw_index)
+            except (TypeError, ValueError):
+                tool_index = 0
+            fn = raw_tool_call.get("function", {})
+            if not isinstance(fn, dict):
+                fn = {}
+            tool_id = raw_tool_call.get("id")
+            tool_name = fn.get("name")
+            if isinstance(tool_id, str) and tool_id and isinstance(tool_name, str) and tool_name:
+                if state.content_block_open:
+                    events.append(
+                        {
+                            "type": "content_block_stop",
+                            "index": state.content_block_index,
+                        }
+                    )
+                    state.content_block_index += 1
+                    state.content_block_open = False
+
+                block_index = state.content_block_index
+                state.tool_calls[tool_index] = ToolCallState(
+                    id=tool_id,
+                    name=tool_name,
+                    anthropic_block_index=block_index,
+                )
+                events.append(
+                    {
+                        "type": "content_block_start",
+                        "index": block_index,
+                        "content_block": {
+                            "type": "tool_use",
+                            "id": tool_id,
+                            "name": tool_name,
+                            "input": {},
+                        },
+                    }
+                )
+                state.content_block_open = True
+
+            arguments = fn.get("arguments")
+            tool_info = state.tool_calls.get(tool_index)
+            if isinstance(arguments, str) and arguments and tool_info is not None:
+                events.append(
+                    {
+                        "type": "content_block_delta",
+                        "index": tool_info.anthropic_block_index,
+                        "delta": {"type": "input_json_delta", "partial_json": arguments},
+                    }
+                )
+
+    finish_reason = choice.get("finish_reason")
+    if finish_reason:
+        if state.content_block_open:
+            events.append(
+                {
+                    "type": "content_block_stop",
+                    "index": state.content_block_index,
+                }
+            )
+            state.content_block_open = False
+
+        usage = {
+            "input_tokens": max(0, prompt_tokens - cached_tokens),
+            "output_tokens": completion_tokens,
+        }
+        if cached_tokens:
+            usage["cache_read_input_tokens"] = cached_tokens
+
+        events.extend(
+            [
+                {
+                    "type": "message_delta",
+                    "delta": {
+                        "stop_reason": map_openai_stop_reason_to_anthropic(str(finish_reason)),
+                        "stop_sequence": None,
+                    },
+                    "usage": usage,
+                },
+                {"type": "message_stop"},
+            ]
+        )
+
+    return events

--- a/src/cc_dump/proxies/plugin_api.py
+++ b/src/cc_dump/proxies/plugin_api.py
@@ -1,0 +1,73 @@
+"""Standard proxy-plugin contract for provider-specific behavior.
+
+// [LAW:one-source-of-truth] Provider capabilities and settings descriptors are defined here.
+// [LAW:locality-or-seam] Core proxy code talks only to this contract, never provider internals.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, Mapping, Protocol
+
+from cc_dump.proxies.runtime import ProxyRuntimeSnapshot
+
+
+SettingKind = Literal["text", "bool", "select"]
+
+
+@dataclass(frozen=True)
+class ProxySettingDescriptor:
+    key: str
+    label: str
+    description: str
+    kind: SettingKind
+    default: object
+    options: tuple[str, ...] = ()
+    secret: bool = False
+    env_vars: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class ProxyProviderDescriptor:
+    provider_id: str
+    display_name: str
+    settings: tuple[ProxySettingDescriptor, ...]
+
+
+@dataclass(frozen=True)
+class ProxyAuthResult:
+    settings_updates: Mapping[str, object]
+    message: str
+
+
+@dataclass(frozen=True)
+class ProxyRequestContext:
+    request_id: str
+    request_path: str
+    request_body: dict | None
+    method: str
+    request_headers: Mapping[str, str]
+    runtime_snapshot: ProxyRuntimeSnapshot
+    handler: Any
+    event_queue: Any
+    safe_headers: Any
+
+
+class ProxyProviderPlugin(Protocol):
+    @property
+    def descriptor(self) -> ProxyProviderDescriptor:
+        ...
+
+    def handles_path(self, request_path: str) -> bool:
+        ...
+
+    def expects_json_body(self, request_path: str) -> bool:
+        ...
+
+    def handle_request(self, context: ProxyRequestContext) -> bool:
+        ...
+
+
+class ProxyAuthCapablePlugin(Protocol):
+    def run_auth_flow(self, *, force: bool) -> ProxyAuthResult:
+        ...

--- a/src/cc_dump/proxies/registry.py
+++ b/src/cc_dump/proxies/registry.py
@@ -1,0 +1,156 @@
+"""Proxy provider registry and descriptor helpers.
+
+// [LAW:one-source-of-truth] Provider registration + settings descriptors are centralized here.
+"""
+
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from collections.abc import Mapping
+
+from cc_dump.proxies.plugin_api import (
+    ProxyProviderDescriptor,
+    ProxyProviderPlugin,
+    ProxySettingDescriptor,
+)
+from cc_dump.proxies.runtime import PROVIDER_ANTHROPIC
+
+
+_ANTHROPIC_DESCRIPTOR = ProxyProviderDescriptor(
+    provider_id=PROVIDER_ANTHROPIC,
+    display_name="Anthropic",
+    settings=(
+        ProxySettingDescriptor(
+            key="proxy_anthropic_base_url",
+            label="Anthropic URL",
+            description="Base URL when provider=anthropic",
+            kind="text",
+            default="https://api.anthropic.com",
+            env_vars=("ANTHROPIC_BASE_URL",),
+        ),
+    ),
+)
+
+_DESCRIPTORS: dict[str, ProxyProviderDescriptor] = {
+    _ANTHROPIC_DESCRIPTOR.provider_id: _ANTHROPIC_DESCRIPTOR,
+}
+_PLUGINS: dict[str, ProxyProviderPlugin] = {}
+_PLUGIN_LOAD_ERRORS: dict[str, str] = {}
+_REGISTRY_READY = False
+_REGISTRY_LOADING = False
+
+
+def _discover_plugin_package_names() -> tuple[str, ...]:
+    root = Path(__file__).resolve().parent
+    # // [LAW:dataflow-not-control-flow] Discovery is deterministic from package layout.
+    package_names = sorted(
+        entry.name
+        for entry in root.iterdir()
+        if entry.is_dir()
+        and not entry.name.startswith("_")
+        and (entry / "plugin.py").exists()
+    )
+    return tuple(package_names)
+
+
+def _load_plugin_from_package(package_name: str) -> None:
+    module_name = f"cc_dump.proxies.{package_name}.plugin"
+    try:
+        module = importlib.import_module(module_name)
+    except Exception as e:
+        _PLUGIN_LOAD_ERRORS[package_name] = f"import failed: {e}"
+        return
+
+    create_plugin = getattr(module, "create_plugin", None)
+    if create_plugin is None or not callable(create_plugin):
+        _PLUGIN_LOAD_ERRORS[package_name] = (
+            "missing required create_plugin() factory"
+        )
+        return
+    try:
+        plugin = create_plugin()
+        descriptor = plugin.descriptor
+    except Exception as e:
+        _PLUGIN_LOAD_ERRORS[package_name] = f"factory failed: {e}"
+        return
+    provider_id = str(descriptor.provider_id or "").strip().lower()
+    if not provider_id:
+        _PLUGIN_LOAD_ERRORS[package_name] = "invalid empty provider_id"
+        return
+    if provider_id in _DESCRIPTORS:
+        _PLUGIN_LOAD_ERRORS[package_name] = f"duplicate provider_id '{provider_id}'"
+        return
+    _DESCRIPTORS[provider_id] = descriptor
+    _PLUGINS[provider_id] = plugin
+
+
+def _ensure_registry_loaded() -> None:
+    global _REGISTRY_READY, _REGISTRY_LOADING
+    if _REGISTRY_READY or _REGISTRY_LOADING:
+        return
+    _REGISTRY_LOADING = True
+    # // [LAW:single-enforcer] Plugin loading/validation is centralized in one registry bootstrap.
+    try:
+        for package_name in _discover_plugin_package_names():
+            _load_plugin_from_package(package_name)
+        _REGISTRY_READY = True
+    finally:
+        _REGISTRY_LOADING = False
+
+
+def provider_ids() -> tuple[str, ...]:
+    _ensure_registry_loaded()
+    return tuple(_DESCRIPTORS.keys())
+
+
+def provider_descriptors() -> tuple[ProxyProviderDescriptor, ...]:
+    _ensure_registry_loaded()
+    return tuple(_DESCRIPTORS.values())
+
+
+def provider_descriptor(provider_id: str) -> ProxyProviderDescriptor | None:
+    _ensure_registry_loaded()
+    return _DESCRIPTORS.get(str(provider_id or "").strip().lower())
+
+
+def provider_plugin(provider_id: str) -> ProxyProviderPlugin | None:
+    _ensure_registry_loaded()
+    return _PLUGINS.get(str(provider_id or "").strip().lower())
+
+
+def all_setting_descriptors() -> tuple[ProxySettingDescriptor, ...]:
+    _ensure_registry_loaded()
+    output: list[ProxySettingDescriptor] = []
+    seen: set[str] = set()
+    for descriptor in provider_descriptors():
+        for setting in descriptor.settings:
+            key = str(setting.key or "").strip()
+            if key and key not in seen:
+                output.append(setting)
+                seen.add(key)
+    return tuple(output)
+
+
+def apply_env_overrides(
+    current: Mapping[str, object],
+    environ: Mapping[str, str],
+) -> dict[str, object]:
+    _ensure_registry_loaded()
+    # // [LAW:dataflow-not-control-flow] All descriptors are processed through one deterministic override pass.
+    updated = dict(current)
+    for setting in all_setting_descriptors():
+        if not setting.env_vars:
+            continue
+        for env_var in setting.env_vars:
+            if env_var in environ:
+                updated[setting.key] = environ[env_var]
+                break
+    if "CC_DUMP_PROXY_PROVIDER" in environ:
+        updated["proxy_provider"] = environ["CC_DUMP_PROXY_PROVIDER"]
+    return updated
+
+
+def plugin_load_errors() -> Mapping[str, str]:
+    _ensure_registry_loaded()
+    return dict(_PLUGIN_LOAD_ERRORS)

--- a/src/cc_dump/proxies/runtime.py
+++ b/src/cc_dump/proxies/runtime.py
@@ -1,0 +1,121 @@
+"""Runtime-switchable upstream proxy configuration.
+
+// [LAW:one-source-of-truth] Runtime keeps one canonical provider + settings snapshot.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import threading
+from typing import Mapping
+
+
+PROVIDER_ANTHROPIC = "anthropic"
+
+
+def _normalize_provider(value: object) -> str:
+    raw = str(value or "").strip().lower()
+    if not raw:
+        return PROVIDER_ANTHROPIC
+    return raw
+
+
+def _normalize_url(value: object) -> str:
+    return str(value or "").strip().rstrip("/")
+
+
+def _normalize_rate_limit_seconds(value: object) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = 0
+    return max(0, parsed)
+
+
+def _normalize_bool(value: object, *, default: bool = False) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    raw = str(value).strip().lower()
+    if raw in {"1", "true", "yes", "on"}:
+        return True
+    if raw in {"0", "false", "no", "off"}:
+        return False
+    return default
+
+
+def _normalize_value(key: str, value: object) -> object:
+    # // [LAW:dataflow-not-control-flow] One deterministic normalization pipeline for all settings.
+    if key.endswith("_base_url"):
+        return _normalize_url(value)
+    if key.endswith("_rate_limit_seconds"):
+        return _normalize_rate_limit_seconds(value)
+    if key.endswith("_rate_limit_wait"):
+        return _normalize_bool(value, default=False)
+    return value
+
+
+@dataclass(frozen=True)
+class ProxyRuntimeSnapshot:
+    provider: str
+    settings: Mapping[str, object]
+
+    def get(self, key: str, default: object = None) -> object:
+        return self.settings.get(key, default)
+
+    def get_text(self, key: str, default: str = "") -> str:
+        value = self.settings.get(key, default)
+        return str(value if value is not None else default).strip()
+
+    def get_bool(self, key: str, default: bool = False) -> bool:
+        return _normalize_bool(self.settings.get(key), default=default)
+
+    def get_int(self, key: str, default: int = 0) -> int:
+        try:
+            parsed = int(self.settings.get(key, default))
+        except (TypeError, ValueError):
+            parsed = default
+        return parsed
+
+    @property
+    def active_base_url(self) -> str:
+        if self.provider == PROVIDER_ANTHROPIC:
+            return self.get_text("proxy_anthropic_base_url")
+        provider_key = f"proxy_{self.provider}_base_url"
+        provider_url = self.get_text(provider_key)
+        if provider_url:
+            return provider_url
+        return self.get_text("proxy_anthropic_base_url")
+
+    @property
+    def reverse_proxy_enabled(self) -> bool:
+        return bool(self.active_base_url)
+
+
+class ProxyRuntime:
+    """Thread-safe mutable store for active proxy provider + settings."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._snapshot = ProxyRuntimeSnapshot(
+            provider=PROVIDER_ANTHROPIC,
+            settings={},
+        )
+
+    def update_from_settings(self, settings: Mapping[str, object]) -> ProxyRuntimeSnapshot:
+        normalized = {
+            str(key): _normalize_value(str(key), value)
+            for key, value in dict(settings).items()
+        }
+        snapshot = ProxyRuntimeSnapshot(
+            provider=_normalize_provider(normalized.get("proxy_provider")),
+            settings=normalized,
+        )
+        with self._lock:
+            self._snapshot = snapshot
+            return self._snapshot
+
+    def snapshot(self) -> ProxyRuntimeSnapshot:
+        with self._lock:
+            return self._snapshot

--- a/src/cc_dump/tui/proxy_settings_panel.py
+++ b/src/cc_dump/tui/proxy_settings_panel.py
@@ -1,0 +1,67 @@
+"""Proxy settings panel (provider + provider-specific descriptors).
+
+This module is RELOADABLE.
+"""
+
+from __future__ import annotations
+
+import cc_dump.app.settings_store
+import cc_dump.proxies.registry
+from cc_dump.tui.settings_form_panel import FieldDef, SettingsFormPanel
+
+
+def _provider_setting_fields() -> list[FieldDef]:
+    fields: list[FieldDef] = []
+    for descriptor in cc_dump.proxies.registry.all_setting_descriptors():
+        if descriptor.kind == "bool":
+            default_value: str | bool = bool(descriptor.default)
+        else:
+            default_value = str(descriptor.default)
+        fields.append(
+            FieldDef(
+                key=descriptor.key,
+                label=descriptor.label,
+                description=descriptor.description,
+                kind=descriptor.kind,
+                default=default_value,
+                options=tuple(descriptor.options),
+                secret=bool(descriptor.secret),
+            )
+        )
+    return fields
+
+
+def build_proxy_settings_fields() -> list[FieldDef]:
+    provider_options = tuple(
+        descriptor.provider_id
+        for descriptor in cc_dump.proxies.registry.provider_descriptors()
+    )
+    # // [LAW:one-source-of-truth] Proxy field list derives from provider descriptors only.
+    return [
+        FieldDef(
+            key="proxy_provider",
+            label="Proxy Provider",
+            description="Active upstream adapter (switches live)",
+            kind="select",
+            options=provider_options,
+            default=str(cc_dump.app.settings_store.SCHEMA["proxy_provider"]),
+        ),
+        *_provider_setting_fields(),
+    ]
+
+
+PROXY_SETTINGS_FIELDS: tuple[FieldDef, ...] = tuple(build_proxy_settings_fields())
+
+
+class ProxySettingsPanel(SettingsFormPanel):
+    def __init__(self, initial_values: dict | None = None) -> None:
+        super().__init__(
+            panel_key="proxy_settings",
+            title="Proxy Settings",
+            fields=PROXY_SETTINGS_FIELDS,
+            initial_values=initial_values,
+        )
+
+
+def create_proxy_settings_panel(initial_values: dict | None = None) -> ProxySettingsPanel:
+    return ProxySettingsPanel(initial_values=initial_values)

--- a/tests/test_copilot_auth.py
+++ b/tests/test_copilot_auth.py
@@ -1,0 +1,29 @@
+from cc_dump.proxies.copilot.auth import DeviceCodeResponse, poll_access_token
+
+
+def test_poll_access_token_retries_pending(monkeypatch):
+    responses = iter(
+        [
+            {"error": "authorization_pending"},
+            {"access_token": "gho_test"},
+        ]
+    )
+
+    def fake_json_request(url: str, *, body: dict[str, object]):
+        _ = url
+        _ = body
+        return next(responses)
+
+    monkeypatch.setattr("cc_dump.proxies.copilot.auth._json_request", fake_json_request)
+    monkeypatch.setattr("time.sleep", lambda *_: None)
+
+    token = poll_access_token(
+        DeviceCodeResponse(
+            device_code="dev",
+            user_code="USER",
+            verification_uri="https://github.com/login/device",
+            expires_in=300,
+            interval=1,
+        )
+    )
+    assert token == "gho_test"

--- a/tests/test_copilot_provider.py
+++ b/tests/test_copilot_provider.py
@@ -1,0 +1,143 @@
+from cc_dump.proxies.copilot import provider
+from cc_dump.proxies.runtime import ProxyRuntime
+
+
+def _snapshot(**overrides):
+    runtime = ProxyRuntime()
+    data = {
+        "proxy_provider": "copilot",
+        "proxy_anthropic_base_url": "https://api.anthropic.com",
+        "proxy_copilot_base_url": "https://api.githubcopilot.com",
+        "proxy_copilot_token": "",
+        "proxy_copilot_github_token": "",
+        "proxy_copilot_account_type": "individual",
+        "proxy_copilot_vscode_version": "1.99.0",
+    }
+    data.update(overrides)
+    runtime.update_from_settings(data)
+    return runtime.snapshot()
+
+
+def test_prepare_messages_request_uses_explicit_copilot_token():
+    snapshot = _snapshot(proxy_copilot_token="copilot_token_123")
+    request, error = provider.prepare_messages_request(
+        snapshot=snapshot,
+        anthropic_payload={
+            "model": "claude-sonnet-4-20251001",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
+    )
+    assert error is None
+    assert request is not None
+    assert request.url.endswith("/chat/completions")
+    assert request.headers["Authorization"] == "Bearer copilot_token_123"
+
+
+def test_prepare_messages_request_errors_without_auth():
+    snapshot = _snapshot()
+    request, error = provider.prepare_messages_request(
+        snapshot=snapshot,
+        anthropic_payload={
+            "model": "claude-sonnet-4-20251001",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+    assert request is None
+    assert error is not None
+
+
+def test_prepare_models_request_uses_explicit_copilot_token():
+    snapshot = _snapshot(proxy_copilot_token="copilot_token_abc")
+    request, error = provider.prepare_models_request(snapshot=snapshot)
+    assert error is None
+    assert request is not None
+    assert request.url.endswith("/models")
+    assert request.headers["Authorization"] == "Bearer copilot_token_abc"
+
+
+def test_prepare_usage_request_requires_github_token():
+    snapshot = _snapshot()
+    request, error = provider.prepare_usage_request(snapshot=snapshot)
+    assert request is None
+    assert error is not None
+
+
+def test_prepare_usage_request_builds_github_api_call():
+    snapshot = _snapshot(
+        proxy_copilot_github_token="gho_123",
+        proxy_copilot_vscode_version="1.92.0",
+    )
+    request, error = provider.prepare_usage_request(snapshot=snapshot)
+    assert error is None
+    assert request is not None
+    assert request.url.endswith("/copilot_internal/user")
+    assert request.method == "GET"
+    assert request.headers["authorization"] == "token gho_123"
+    assert request.headers["editor-version"] == "vscode/1.92.0"
+
+
+def test_prepare_openai_chat_request_passthrough():
+    snapshot = _snapshot(proxy_copilot_token="copilot_token_abc")
+    request, error = provider.prepare_openai_chat_request(
+        snapshot=snapshot,
+        openai_payload={
+            "model": "claude-sonnet-4",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": True,
+        },
+    )
+    assert error is None
+    assert request is not None
+    assert request.stream is True
+    assert request.url.endswith("/chat/completions")
+    assert request.headers["Authorization"] == "Bearer copilot_token_abc"
+
+
+def test_prepare_openai_embeddings_request():
+    snapshot = _snapshot(proxy_copilot_token="copilot_token_abc")
+    request, error = provider.prepare_openai_embeddings_request(
+        snapshot=snapshot,
+        openai_payload={
+            "model": "text-embedding-3-large",
+            "input": "hello world",
+        },
+    )
+    assert error is None
+    assert request is not None
+    assert request.url.endswith("/embeddings")
+    assert request.stream is False
+    assert request.headers["Authorization"] == "Bearer copilot_token_abc"
+
+
+def test_prepare_messages_request_uses_configured_vscode_version():
+    snapshot = _snapshot(
+        proxy_copilot_token="copilot_token_123",
+        proxy_copilot_vscode_version="1.91.0",
+    )
+    request, error = provider.prepare_messages_request(
+        snapshot=snapshot,
+        anthropic_payload={
+            "model": "claude-sonnet-4-20251001",
+            "messages": [{"role": "user", "content": "hello"}],
+            "stream": False,
+        },
+    )
+    assert error is None
+    assert request is not None
+    assert request.headers["editor-version"] == "vscode/1.91.0"
+
+
+def test_count_tokens_for_messages_fallback_on_error(monkeypatch):
+    def _raise(_payload):
+        raise ValueError("bad payload")
+
+    monkeypatch.setattr(provider, "translate_to_openai", _raise)
+    count = provider.count_tokens_for_messages(
+        {
+            "model": "claude-sonnet-4-20251001",
+            "messages": [{"role": "user", "content": "hello"}],
+        }
+    )
+    assert count == 1

--- a/tests/test_copilot_proxy_routes.py
+++ b/tests/test_copilot_proxy_routes.py
@@ -1,0 +1,39 @@
+import cc_dump.proxies.registry
+
+
+def _copilot_plugin():
+    plugin = cc_dump.proxies.registry.provider_plugin("copilot")
+    assert plugin is not None
+    return plugin
+
+
+def test_copilot_supported_paths_include_openai_aliases():
+    plugin = _copilot_plugin()
+    assert plugin.handles_path("/v1/messages")
+    assert plugin.handles_path("/v1/messages/count_tokens")
+    assert plugin.handles_path("/v1/models")
+    assert plugin.handles_path("/models")
+    assert plugin.handles_path("/v1/chat/completions")
+    assert plugin.handles_path("/chat/completions")
+    assert plugin.handles_path("/v1/embeddings")
+    assert plugin.handles_path("/embeddings")
+    assert plugin.handles_path("/usage")
+    assert plugin.handles_path("/v1/usage")
+    assert plugin.handles_path("/token")
+    assert plugin.handles_path("/v1/token")
+    assert not plugin.handles_path("/v1/unknown")
+
+
+def test_json_body_expectations_include_alias_paths():
+    plugin = _copilot_plugin()
+    assert plugin.expects_json_body("/v1/messages")
+    assert plugin.expects_json_body("/v1/messages/count_tokens")
+    assert plugin.expects_json_body("/v1/chat/completions")
+    assert plugin.expects_json_body("/chat/completions")
+    assert plugin.expects_json_body("/v1/embeddings")
+    assert plugin.expects_json_body("/embeddings")
+    assert not plugin.expects_json_body("/models")
+    assert not plugin.expects_json_body("/usage")
+    assert not plugin.expects_json_body("/v1/usage")
+    assert not plugin.expects_json_body("/token")
+    assert not plugin.expects_json_body("/v1/token")

--- a/tests/test_copilot_rate_limit.py
+++ b/tests/test_copilot_rate_limit.py
@@ -1,0 +1,52 @@
+from cc_dump.proxies.copilot.rate_limit import CopilotRateLimiter
+
+
+def test_rate_limiter_allows_when_interval_disabled():
+    limiter = CopilotRateLimiter()
+    allowed, remaining = limiter.gate(min_interval_seconds=0, wait_on_limit=False)
+    assert allowed is True
+    assert remaining == 0.0
+
+
+def test_rate_limiter_rejects_when_wait_disabled(monkeypatch):
+    now = {"t": 100.0}
+
+    def _monotonic():
+        return now["t"]
+
+    monkeypatch.setattr("cc_dump.proxies.copilot.rate_limit.time.monotonic", _monotonic)
+
+    limiter = CopilotRateLimiter()
+    first_allowed, first_remaining = limiter.gate(min_interval_seconds=10, wait_on_limit=False)
+    assert first_allowed is True
+    assert first_remaining == 0.0
+
+    now["t"] = 103.5
+    second_allowed, second_remaining = limiter.gate(min_interval_seconds=10, wait_on_limit=False)
+    assert second_allowed is False
+    assert round(second_remaining, 2) == 6.5
+
+
+def test_rate_limiter_waits_when_configured(monkeypatch):
+    now = {"t": 100.0}
+    sleeps: list[float] = []
+
+    def _monotonic():
+        return now["t"]
+
+    def _sleep(duration: float):
+        sleeps.append(duration)
+        now["t"] += duration
+
+    monkeypatch.setattr("cc_dump.proxies.copilot.rate_limit.time.monotonic", _monotonic)
+    monkeypatch.setattr("cc_dump.proxies.copilot.rate_limit.time.sleep", _sleep)
+
+    limiter = CopilotRateLimiter()
+    limiter.gate(min_interval_seconds=5, wait_on_limit=False)
+
+    now["t"] = 102.0
+    allowed, remaining = limiter.gate(min_interval_seconds=5, wait_on_limit=True)
+    assert allowed is True
+    assert round(remaining, 2) == 3.0
+    assert len(sleeps) == 1
+    assert round(sleeps[0], 2) == 3.0

--- a/tests/test_copilot_token_manager.py
+++ b/tests/test_copilot_token_manager.py
@@ -1,0 +1,62 @@
+import json
+
+import cc_dump.proxies.copilot.token_manager as token_manager
+from cc_dump.proxies.runtime import ProxyRuntime
+
+
+class _FakeHTTPResponse:
+    def __init__(self, payload: dict):
+        self._payload = payload
+
+    def read(self) -> bytes:
+        return json.dumps(self._payload).encode("utf-8")
+
+
+def _snapshot(**overrides):
+    runtime = ProxyRuntime()
+    data = {
+        "proxy_provider": "copilot",
+        "proxy_anthropic_base_url": "https://api.anthropic.com",
+        "proxy_copilot_base_url": "https://api.githubcopilot.com",
+        "proxy_copilot_token": "",
+        "proxy_copilot_github_token": "",
+        "proxy_copilot_account_type": "individual",
+        "proxy_copilot_vscode_version": "1.99.0",
+    }
+    data.update(overrides)
+    runtime.update_from_settings(data)
+    return runtime.snapshot()
+
+
+def test_resolve_copilot_token_prefers_explicit_token():
+    snapshot = _snapshot(proxy_copilot_token="copilot_explicit")
+    token, error = token_manager.resolve_copilot_token(snapshot)
+    assert error is None
+    assert token == "copilot_explicit"
+
+
+def test_resolve_copilot_token_uses_github_fetch(monkeypatch):
+    snapshot = _snapshot(proxy_copilot_github_token="gh_token_123")
+
+    def fake_urlopen(request, timeout=0):
+        _ = request
+        _ = timeout
+        return _FakeHTTPResponse(
+            {
+                "token": "copilot_from_gh",
+                "expires_at": 2_000_000_000,
+                "refresh_in": 1200,
+            }
+        )
+
+    monkeypatch.setattr(token_manager.urllib.request, "urlopen", fake_urlopen)
+    token, error = token_manager.resolve_copilot_token(snapshot)
+    assert error is None
+    assert token == "copilot_from_gh"
+
+
+def test_resolve_copilot_token_errors_without_any_auth():
+    snapshot = _snapshot()
+    token, error = token_manager.resolve_copilot_token(snapshot)
+    assert token == ""
+    assert "Missing" in str(error)

--- a/tests/test_copilot_translation.py
+++ b/tests/test_copilot_translation.py
@@ -1,0 +1,137 @@
+from cc_dump.proxies.copilot.translation import (
+    AnthropicStreamState,
+    translate_chunk_to_anthropic_events,
+    translate_error_to_anthropic,
+    translate_models_to_anthropic,
+    translate_stream_error_to_anthropic,
+    translate_to_anthropic,
+    translate_to_openai,
+)
+
+
+def test_translate_to_openai_maps_model_and_messages():
+    anthropic_payload = {
+        "model": "claude-sonnet-4-20251001",
+        "system": [{"type": "text", "text": "sys-a"}, {"type": "text", "text": "sys-b"}],
+        "messages": [
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "hello"}],
+            }
+        ],
+        "stream": True,
+        "tools": [
+            {
+                "name": "Read",
+                "description": "Read file",
+                "input_schema": {"type": "object"},
+            }
+        ],
+    }
+    openai_payload = translate_to_openai(anthropic_payload)
+    assert openai_payload["model"] == "claude-sonnet-4"
+    assert openai_payload["messages"][0] == {"role": "system", "content": "sys-a\n\nsys-b"}
+    assert openai_payload["messages"][1] == {"role": "user", "content": "hello"}
+    assert openai_payload["tools"][0]["function"]["name"] == "Read"
+
+
+def test_translate_to_anthropic_maps_usage_and_tool_calls():
+    openai_response = {
+        "id": "chatcmpl_123",
+        "model": "claude-sonnet-4",
+        "choices": [
+            {
+                "finish_reason": "tool_calls",
+                "message": {
+                    "content": "Done",
+                    "tool_calls": [
+                        {
+                            "id": "call_1",
+                            "function": {"name": "Read", "arguments": '{"path":"x.py"}'},
+                        }
+                    ],
+                },
+            }
+        ],
+        "usage": {
+            "prompt_tokens": 100,
+            "completion_tokens": 7,
+            "prompt_tokens_details": {"cached_tokens": 20},
+        },
+    }
+    anthropic_response = translate_to_anthropic(openai_response)
+    assert anthropic_response["id"] == "chatcmpl_123"
+    assert anthropic_response["stop_reason"] == "tool_use"
+    assert anthropic_response["usage"]["input_tokens"] == 80
+    assert anthropic_response["usage"]["cache_read_input_tokens"] == 20
+    assert anthropic_response["usage"]["output_tokens"] == 7
+    assert anthropic_response["content"][0] == {"type": "text", "text": "Done"}
+    assert anthropic_response["content"][1]["type"] == "tool_use"
+    assert anthropic_response["content"][1]["input"] == {"path": "x.py"}
+
+
+def test_translate_chunk_to_anthropic_events_emits_message_start_and_stop():
+    state = AnthropicStreamState()
+    first_chunk = {
+        "id": "chunk_1",
+        "model": "claude-sonnet-4",
+        "choices": [{"delta": {"content": "hello "}, "finish_reason": None}],
+        "usage": {"prompt_tokens": 50, "completion_tokens": 0},
+    }
+    first_events = translate_chunk_to_anthropic_events(first_chunk, state)
+    first_types = [event["type"] for event in first_events]
+    assert first_types == ["message_start", "content_block_start", "content_block_delta"]
+    assert first_events[0]["message"]["usage"]["input_tokens"] == 50
+
+    end_chunk = {
+        "id": "chunk_1",
+        "model": "claude-sonnet-4",
+        "choices": [{"delta": {}, "finish_reason": "stop"}],
+        "usage": {"prompt_tokens": 50, "completion_tokens": 3},
+    }
+    end_events = translate_chunk_to_anthropic_events(end_chunk, state)
+    end_types = [event["type"] for event in end_events]
+    assert end_types == ["content_block_stop", "message_delta", "message_stop"]
+    assert end_events[1]["delta"]["stop_reason"] == "end_turn"
+    assert end_events[1]["usage"]["output_tokens"] == 3
+
+
+def test_translate_models_to_anthropic_shape():
+    copilot_models = {
+        "object": "list",
+        "data": [
+            {"id": "claude-sonnet-4", "name": "Claude Sonnet 4"},
+            {"id": "gpt-4.1", "name": "GPT-4.1"},
+        ],
+    }
+    translated = translate_models_to_anthropic(copilot_models)
+    assert translated["has_more"] is False
+    assert translated["first_id"] == "claude-sonnet-4"
+    assert translated["last_id"] == "gpt-4.1"
+    assert translated["data"][0]["type"] == "model"
+    assert translated["data"][0]["display_name"] == "Claude Sonnet 4"
+
+
+def test_translate_error_to_anthropic_shape():
+    translated = translate_error_to_anthropic(
+        {"error": {"type": "invalid_request_error", "message": "bad input"}},
+        fallback_message="fallback",
+    )
+    assert translated == {
+        "type": "error",
+        "error": {
+            "type": "invalid_request_error",
+            "message": "bad input",
+        },
+    }
+
+
+def test_translate_stream_error_to_anthropic_shape():
+    translated = translate_stream_error_to_anthropic()
+    assert translated == {
+        "type": "error",
+        "error": {
+            "type": "api_error",
+            "message": "An unexpected error occurred during streaming.",
+        },
+    }

--- a/tests/test_proxy_pipeline_isolation.py
+++ b/tests/test_proxy_pipeline_isolation.py
@@ -1,0 +1,7 @@
+from pathlib import Path
+
+
+def test_proxy_pipeline_has_no_provider_specific_imports():
+    source = Path("/Users/bmf/code/cc-dump/src/cc_dump/pipeline/proxy.py").read_text()
+    assert "cc_dump.proxies.copilot" not in source
+    assert "_COPILOT_" not in source

--- a/tests/test_proxy_plugin_boundary.py
+++ b/tests/test_proxy_plugin_boundary.py
@@ -1,0 +1,63 @@
+import io
+import queue
+
+from cc_dump.pipeline.event_types import ProxyErrorEvent
+from cc_dump.pipeline.proxy import ProxyHandler
+from cc_dump.proxies.runtime import ProxyRuntime
+
+
+class _RaisingPlugin:
+    def handles_path(self, _request_path: str) -> bool:
+        return True
+
+    def handle_request(self, _context) -> bool:
+        raise RuntimeError("boom")
+
+
+class _FakeHandler:
+    def __init__(self) -> None:
+        self.event_queue = queue.Queue()
+        self.command = "POST"
+        self.headers = {}
+        self.sent_status = None
+        self.sent_headers: list[tuple[str, str]] = []
+        self.wfile = io.BytesIO()
+
+    def send_response(self, code: int) -> None:
+        self.sent_status = code
+
+    def send_header(self, key: str, value: str) -> None:
+        self.sent_headers.append((key, value))
+
+    def end_headers(self) -> None:
+        pass
+
+
+def test_provider_plugin_failure_isolated_to_502():
+    runtime = ProxyRuntime()
+    snapshot = runtime.update_from_settings(
+        {
+            "proxy_provider": "copilot",
+            "proxy_anthropic_base_url": "https://api.anthropic.com",
+        }
+    )
+    handler = _FakeHandler()
+
+    handled = ProxyHandler._dispatch_provider_plugin(
+        handler,
+        provider_plugin=_RaisingPlugin(),
+        request_id="req_1",
+        request_path="/v1/messages",
+        body={},
+        runtime_snapshot=snapshot,
+    )
+
+    assert handled is True
+    assert handler.sent_status == 502
+    body_text = handler.wfile.getvalue().decode("utf-8", errors="replace")
+    assert "Provider plugin 'copilot' failed" in body_text
+
+    events = []
+    while not handler.event_queue.empty():
+        events.append(handler.event_queue.get_nowait())
+    assert any(isinstance(event, ProxyErrorEvent) for event in events)

--- a/tests/test_proxy_registry.py
+++ b/tests/test_proxy_registry.py
@@ -1,0 +1,52 @@
+from pathlib import Path
+
+import cc_dump.app.settings_store
+import cc_dump.proxies.registry
+
+
+def test_registry_exposes_provider_descriptors():
+    provider_ids = cc_dump.proxies.registry.provider_ids()
+    assert "anthropic" in provider_ids
+    assert "copilot" in provider_ids
+
+
+def test_copilot_plugin_conforms_to_contract_shape():
+    plugin = cc_dump.proxies.registry.provider_plugin("copilot")
+    assert plugin is not None
+    assert hasattr(plugin, "descriptor")
+    assert hasattr(plugin, "handles_path")
+    assert hasattr(plugin, "expects_json_body")
+    assert hasattr(plugin, "handle_request")
+
+
+def test_registry_settings_are_reflected_in_settings_schema():
+    descriptor_keys = {
+        descriptor.key
+        for descriptor in cc_dump.proxies.registry.all_setting_descriptors()
+    }
+    assert descriptor_keys
+    for key in descriptor_keys:
+        assert key in cc_dump.app.settings_store.SCHEMA
+
+
+def test_registry_applies_env_overrides_from_descriptors():
+    overrides = cc_dump.proxies.registry.apply_env_overrides(
+        {"proxy_provider": "anthropic"},
+        {
+            "CC_DUMP_PROXY_PROVIDER": "copilot",
+            "CC_DUMP_COPILOT_BASE_URL": "https://copilot.example.com",
+        },
+    )
+    assert overrides["proxy_provider"] == "copilot"
+    assert overrides["proxy_copilot_base_url"] == "https://copilot.example.com"
+
+
+def test_registry_uses_generic_plugin_discovery_without_provider_imports():
+    source = Path("/Users/bmf/code/cc-dump/src/cc_dump/proxies/registry.py").read_text()
+    assert "cc_dump.proxies.copilot" not in source
+    assert "create_plugin()" in source
+
+
+def test_registry_exposes_plugin_load_errors_mapping():
+    errors = cc_dump.proxies.registry.plugin_load_errors()
+    assert isinstance(errors, dict)

--- a/tests/test_proxy_runtime.py
+++ b/tests/test_proxy_runtime.py
@@ -1,0 +1,64 @@
+from cc_dump.proxies.runtime import (
+    PROVIDER_ANTHROPIC,
+    ProxyRuntime,
+)
+
+
+def test_proxy_runtime_updates_from_settings():
+    runtime = ProxyRuntime()
+    snapshot = runtime.update_from_settings(
+        {
+            "proxy_provider": "copilot",
+            "proxy_anthropic_base_url": "https://api.anthropic.com/",
+            "proxy_copilot_base_url": "https://api.githubcopilot.com/",
+            "proxy_copilot_token": "tok_123",
+            "proxy_copilot_account_type": "business",
+            "proxy_copilot_rate_limit_seconds": "15",
+            "proxy_copilot_rate_limit_wait": "true",
+        }
+    )
+    assert snapshot.provider == "copilot"
+    assert snapshot.get_text("proxy_anthropic_base_url") == "https://api.anthropic.com"
+    assert snapshot.get_text("proxy_copilot_base_url") == "https://api.githubcopilot.com"
+    assert snapshot.get_text("proxy_copilot_token") == "tok_123"
+    assert snapshot.get_text("proxy_copilot_account_type") == "business"
+    assert snapshot.get_text("proxy_copilot_vscode_version", "1.99.0") == "1.99.0"
+    assert snapshot.get_int("proxy_copilot_rate_limit_seconds") == 15
+    assert snapshot.get_bool("proxy_copilot_rate_limit_wait") is True
+    assert snapshot.active_base_url == "https://api.githubcopilot.com"
+    assert snapshot.reverse_proxy_enabled is True
+
+
+def test_proxy_runtime_normalizes_invalid_provider_fields():
+    runtime = ProxyRuntime()
+    snapshot = runtime.update_from_settings(
+        {
+            "proxy_provider": "invalid",
+            "proxy_anthropic_base_url": " https://a.example.com/ ",
+            "proxy_copilot_base_url": " https://c.example.com/ ",
+            "proxy_copilot_token": "  token  ",
+            "proxy_copilot_account_type": "unknown",
+            "proxy_copilot_rate_limit_seconds": "-5",
+            "proxy_copilot_rate_limit_wait": "not-a-bool",
+        }
+    )
+    assert snapshot.provider == "invalid"
+    assert snapshot.get_text("proxy_anthropic_base_url") == "https://a.example.com"
+    assert snapshot.get_text("proxy_copilot_base_url") == "https://c.example.com"
+    assert snapshot.get_text("proxy_copilot_account_type") == "unknown"
+    assert snapshot.get_int("proxy_copilot_rate_limit_seconds") == 0
+    assert snapshot.get_bool("proxy_copilot_rate_limit_wait") is False
+    assert snapshot.active_base_url == "https://a.example.com"
+
+
+def test_proxy_runtime_unknown_provider_uses_provider_specific_base_url():
+    runtime = ProxyRuntime()
+    snapshot = runtime.update_from_settings(
+        {
+            "proxy_provider": "custom",
+            "proxy_anthropic_base_url": "https://anthropic.example.com/",
+            "proxy_custom_base_url": "https://custom.example.com/",
+        }
+    )
+    assert snapshot.provider == "custom"
+    assert snapshot.active_base_url == "https://custom.example.com"


### PR DESCRIPTION
## Summary
New provider plugin architecture for routing traffic through alternative LLM backends.

### Architecture
- **Plugin API** (`plugin_api.py`): ProxyRequestContext, ProviderPlugin protocol
- **Registry** (`registry.py`): provider discovery, env override mapping
- **Runtime** (`runtime.py`): reactive provider config with snapshot isolation

### Copilot Provider (`proxies/copilot/`)
- OAuth device-flow authentication
- Token lifecycle management with automatic refresh
- Sliding-window rate limiter
- Anthropic-to-OpenAI message translation
- Request dispatch and SSE stream relay

### TUI
- ProxySettingsPanel for provider switching

Not yet wired into CLI or proxy handler — integration is in the next PR.

## Files (26, all new)
`docs/proxy-plugin-api.md`, `proxies/copilot/`, `src/cc_dump/proxies/`, `proxy_settings_panel.py`, 10 test files

## Test plan
- [ ] `uv run pytest tests/test_copilot_*.py tests/test_proxy_*.py -v`
- [ ] Verify proxy module imports cleanly: `python -c "from cc_dump.proxies.registry import provider_plugin"`