### PR TITLE
Improve filter/search responsiveness with render-key and LRU cache

### DIFF
--- a/src/cc_dump/tui/action_handlers.py
+++ b/src/cc_dump/tui/action_handlers.py
@@ -67,6 +67,8 @@ def clear_overrides(app, category_name: str) -> None:
     else:
         all_blocks = [block for td in conv._turns for block in td.blocks]
     conv._view_overrides.clear_category(all_blocks, cat)
+    if hasattr(conv, "mark_overrides_changed"):
+        conv.mark_overrides_changed()
 
 
 def toggle_vis(app, category: str) -> None:


### PR DESCRIPTION
## Summary
- add turn-level render-key caching so rerender skips when width/search/theme/override revisions are unchanged
- remove search-active forced rerenders and queue off-viewport rerenders only when filter snapshot or render-key actually changed
- replace unbounded dict+clear search text cache behavior with SearchTextCache (LRU + owner-based invalidation for pruned turns)
- bump override revision when search/category/toggle flows mutate view overrides

## Validation
- `uv run pytest -q tests/test_search.py tests/test_widget_arch.py`
- `uv run pytest -q tests/test_search_controller_shortcuts.py`
- `uv run python -m compileall -q src/cc_dump/tui/search.py src/cc_dump/tui/search_controller.py src/cc_dump/tui/widget_factory.py src/cc_dump/tui/action_handlers.py`