### PR TITLE
Use OS trust store for SSL verification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,7 @@ dependencies = [
     "libtmux>=0.30.0",
     "watchfiles>=1.0.0",
     "snarfx>=0.1.0",
+    "truststore>=0.10.4",
 ]
 keywords = ["claude", "anthropic", "proxy", "api", "debugging", "tui"]
 classifiers = [

--- a/src/cc_dump/pipeline/proxy.py
+++ b/src/cc_dump/pipeline/proxy.py
@@ -4,6 +4,8 @@ import http.server
 import json
 import logging
 import ssl
+
+import truststore
 import time
 import uuid
 import urllib.error
@@ -390,7 +392,7 @@ class ProxyHandler(http.server.BaseHTTPRequestHandler):
             url, data=body_bytes or None, headers=headers, method=self.command
         )
         try:
-            ctx = ssl.create_default_context()
+            ctx = truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
             resp = urllib.request.urlopen(req, context=ctx, timeout=300)
         except urllib.error.HTTPError as e:
             self.event_queue.put(ErrorEvent(

--- a/uv.lock
+++ b/uv.lock
@@ -208,6 +208,7 @@ dependencies = [
     { name = "textual" },
     { name = "textual-serve" },
     { name = "tiktoken" },
+    { name = "truststore" },
     { name = "watchfiles" },
 ]
 
@@ -228,6 +229,7 @@ requires-dist = [
     { name = "textual", specifier = ">=0.80.0" },
     { name = "textual-serve", specifier = ">=1.0.0" },
     { name = "tiktoken", specifier = ">=0.5.0" },
+    { name = "truststore", specifier = ">=0.10.4" },
     { name = "watchfiles", specifier = ">=1.0.0" },
 ]
 
@@ -1484,6 +1486,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/de/69/9aa0c6a505c2f80e519b43764f8b4ba93b5a0bbd2d9a9de6e2b24271b9a5/tomli-2.4.0-cp314-cp314t-win_amd64.whl", hash = "sha256:2add28aacc7425117ff6364fe9e06a183bb0251b03f986df0e78e974047571fd", size = 120504, upload-time = "2026-01-11T11:22:35.764Z" },
     { url = "https://files.pythonhosted.org/packages/b3/9f/f1668c281c58cfae01482f7114a4b88d345e4c140386241a1a24dcc9e7bc/tomli-2.4.0-cp314-cp314t-win_arm64.whl", hash = "sha256:2b1e3b80e1d5e52e40e9b924ec43d81570f0e7d09d11081b797bc4692765a3d4", size = 99561, upload-time = "2026-01-11T11:22:36.624Z" },
     { url = "https://files.pythonhosted.org/packages/23/d1/136eb2cb77520a31e1f64cbae9d33ec6df0d78bdf4160398e86eec8a8754/tomli-2.4.0-py3-none-any.whl", hash = "sha256:1f776e7d669ebceb01dee46484485f43a4048746235e683bcdffacdf1fb4785a", size = 14477, upload-time = "2026-01-11T11:22:37.446Z" },
+]
+
+[[package]]
+name = "truststore"
+version = "0.10.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/53/a3/1585216310e344e8102c22482f6060c7a6ea0322b63e026372e6dcefcfd6/truststore-0.10.4.tar.gz", hash = "sha256:9d91bd436463ad5e4ee4aba766628dd6cd7010cf3e2461756b3303710eebc301", size = 26169, upload-time = "2025-08-12T18:49:02.73Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/19/97/56608b2249fe206a67cd573bc93cd9896e1efb9e98bce9c163bcdc704b88/truststore-0.10.4-py3-none-any.whl", hash = "sha256:adaeaecf1cbb5f4de3b1959b42d41f6fab57b2b1666adb59e89cb0b53361d981", size = 18660, upload-time = "2025-08-12T18:49:01.46Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Adds `truststore` dependency to use the OS trust store instead of Python's bundled `certifi` CA bundle
- Fixes SSL errors for users with self-signed certificates in their system trust store (e.g. corporate proxies, request inspection tools)
- Single-line change in `proxy.py`: `ssl.create_default_context()` → `truststore.SSLContext(ssl.PROTOCOL_TLS_CLIENT)`

## Test plan
- [ ] Run cc-dump behind a proxy with a self-signed cert trusted by the OS — verify no SSL errors
- [ ] Run cc-dump without any custom certs — verify normal operation unchanged