### PR TITLE
Fix duplicate launch execution in TUI launch delegate

### DIFF
--- a/src/cc_dump/tui/settings_launch_controller.py
+++ b/src/cc_dump/tui/settings_launch_controller.py
@@ -6,6 +6,7 @@
 from __future__ import annotations
 
 import cc_dump.app.launch_config
+import cc_dump.tui.launch_config_panel
 import cc_dump.tui.settings_panel
 
 


### PR DESCRIPTION
## Summary
- `src/cc_dump/tui/app.py`: resolve the `_launch_with_config` review-thread regression by keeping a single delegation call to `settings_launch_controller.launch_with_config(...)` and removing the leftover inlined launch body that executed side effects twice
- `src/cc_dump/tui/app.py`: keep `_execute_auto_launch` behavior intact while routing launch side effects through one control-plane boundary

## Removed Behavior
- Removed duplicate launch/configure/notify side effects that occurred after delegate invocation in `_launch_with_config`

## Non-product files
- None

## Validation
- `uv run ruff check src/cc_dump/tui/app.py`
- `uv run pytest`
