### PR TITLE
Fix mypy/ruff regressions in side-channel and TUI modules

### DIFF
--- a/src/cc_dump/ai/side_channel.py
+++ b/src/cc_dump/ai/side_channel.py
@@ -38,6 +38,18 @@ DEFAULT_TIMEOUT_BY_PURPOSE.update({
 })
 
 
+def _coerce_int(value: object) -> int | None:
+    """Best-effort integer conversion for settings payload values."""
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float, str, bytes, bytearray)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
+    return None
+
+
 @dataclass
 class SideChannelResult:
     """Result from a side-channel query.
@@ -106,9 +118,8 @@ class SideChannelManager:
         """Set per-purpose timeout overrides (seconds)."""
         normalized: dict[str, int] = {}
         for key, val in values.items():
-            try:
-                timeout = int(val)
-            except (TypeError, ValueError):
+            timeout = _coerce_int(val)
+            if timeout is None:
                 continue
             normalized[normalize_purpose(str(key))] = max(1, min(MAX_TIMEOUT_SECONDS, timeout))
         self._timeout_overrides = normalized
@@ -117,9 +128,8 @@ class SideChannelManager:
         """Set per-purpose token caps; <=0 removes cap."""
         normalized: dict[str, int] = {}
         for key, val in values.items():
-            try:
-                cap = int(val)
-            except (TypeError, ValueError):
+            cap = _coerce_int(val)
+            if cap is None:
                 continue
             if cap > 0:
                 normalized[normalize_purpose(str(key))] = cap

--- a/src/cc_dump/app/analytics_store.py
+++ b/src/cc_dump/app/analytics_store.py
@@ -123,6 +123,16 @@ class DashboardSummary(TypedDict):
     latest_model_label: str
 
 
+class SideChannelPurposeSummaryRow(TypedDict):
+    turns: int
+    input_tokens: int
+    output_tokens: int
+    cache_read_tokens: int
+    cache_creation_tokens: int
+    prompt_versions: dict[str, int]
+    policy_versions: dict[str, int]
+
+
 class AnalyticsStore:
     """In-memory event subscriber that accumulates analytics data.
 
@@ -487,9 +497,9 @@ class AnalyticsStore:
             "models": model_rows,
         }
 
-    def get_side_channel_purpose_summary(self) -> dict[str, dict[str, object]]:
+    def get_side_channel_purpose_summary(self) -> dict[str, SideChannelPurposeSummaryRow]:
         """Aggregate side-channel token usage by purpose."""
-        summary: dict[str, dict[str, object]] = {}
+        summary: dict[str, SideChannelPurposeSummaryRow] = {}
         for turn in self._turns:
             if not turn.is_side_channel:
                 continue
@@ -512,14 +522,12 @@ class AnalyticsStore:
             row["cache_creation_tokens"] += turn.cache_creation_tokens
             if turn.prompt_version:
                 versions = row["prompt_versions"]
-                if isinstance(versions, dict):
-                    versions[turn.prompt_version] = int(versions.get(turn.prompt_version, 0)) + 1
+                versions[turn.prompt_version] = versions.get(turn.prompt_version, 0) + 1
             if turn.policy_version:
                 policy_versions = row["policy_versions"]
-                if isinstance(policy_versions, dict):
-                    policy_versions[turn.policy_version] = int(
-                        policy_versions.get(turn.policy_version, 0)
-                    ) + 1
+                policy_versions[turn.policy_version] = (
+                    policy_versions.get(turn.policy_version, 0) + 1
+                )
         return summary
 
     def get_tool_economics(self, group_by_model: bool = False) -> list[ToolEconomicsRow]:

--- a/src/cc_dump/app/settings_store.py
+++ b/src/cc_dump/app/settings_store.py
@@ -5,6 +5,7 @@
 """
 
 import logging
+from typing import cast
 
 import cc_dump.io.settings
 from snarfx.hot_reload import HotReloadStore
@@ -35,6 +36,23 @@ def create(initial_overrides: dict | None = None):
     return HotReloadStore(SCHEMA, initial=merged)
 
 
+def _coerce_int(value: object, default: int) -> int:
+    if isinstance(value, bool):
+        return int(value)
+    if isinstance(value, (int, float, str, bytes, bytearray)):
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return default
+    return default
+
+
+def _coerce_str_object_dict(value: object) -> dict[str, object]:
+    if not isinstance(value, dict):
+        return {}
+    return cast(dict[str, object], value)
+
+
 def setup_reactions(store, context=None):
     """Register all reactions. Returns list of disposers.
 
@@ -53,50 +71,105 @@ def setup_reactions(store, context=None):
     if context:
         mgr = context.get("side_channel_manager")
         if mgr is not None:
-            disposers.append(reaction(
-                lambda: store.get("side_channel_enabled"),
-                lambda val, m=mgr: setattr(m, "enabled", val),
-                fire_immediately=True,
-            ))
-            disposers.append(reaction(
-                lambda: store.get("side_channel_global_kill"),
-                lambda val, m=mgr: setattr(m, "global_kill", bool(val)),
-                fire_immediately=True,
-            ))
-            disposers.append(reaction(
-                lambda: int(store.get("side_channel_max_concurrent") or 1),
-                lambda val, m=mgr: m.set_max_concurrent(int(val)),
-                fire_immediately=True,
-            ))
-            disposers.append(reaction(
-                lambda: store.get("side_channel_purpose_enabled"),
-                lambda val, m=mgr: m.set_purpose_enabled_map(
-                    val if isinstance(val, dict) else {}
-                ),
-                fire_immediately=True,
-            ))
-            disposers.append(reaction(
-                lambda: store.get("side_channel_timeout_by_purpose"),
-                lambda val, m=mgr: m.set_timeout_overrides(
-                    val if isinstance(val, dict) else {}
-                ),
-                fire_immediately=True,
-            ))
-            disposers.append(reaction(
-                lambda: store.get("side_channel_budget_caps"),
-                lambda val, m=mgr: m.set_budget_caps(
-                    val if isinstance(val, dict) else {}
-                ),
-                fire_immediately=True,
-            ))
+            def _select_side_channel_enabled() -> bool:
+                return bool(store.get("side_channel_enabled"))
+
+            def _apply_side_channel_enabled(val: bool) -> None:
+                mgr.enabled = val
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_enabled,
+                    _apply_side_channel_enabled,
+                    fire_immediately=True,
+                )
+            )
+
+            def _select_side_channel_global_kill() -> bool:
+                return bool(store.get("side_channel_global_kill"))
+
+            def _apply_side_channel_global_kill(val: bool) -> None:
+                mgr.global_kill = val
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_global_kill,
+                    _apply_side_channel_global_kill,
+                    fire_immediately=True,
+                )
+            )
+
+            def _select_side_channel_max_concurrent() -> int:
+                return _coerce_int(store.get("side_channel_max_concurrent"), 1)
+
+            def _apply_side_channel_max_concurrent(val: int) -> None:
+                mgr.set_max_concurrent(val)
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_max_concurrent,
+                    _apply_side_channel_max_concurrent,
+                    fire_immediately=True,
+                )
+            )
+
+            def _select_side_channel_purpose_enabled() -> dict[str, object]:
+                return _coerce_str_object_dict(store.get("side_channel_purpose_enabled"))
+
+            def _apply_side_channel_purpose_enabled(val: dict[str, object]) -> None:
+                mgr.set_purpose_enabled_map(val)
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_purpose_enabled,
+                    _apply_side_channel_purpose_enabled,
+                    fire_immediately=True,
+                )
+            )
+
+            def _select_side_channel_timeout_by_purpose() -> dict[str, object]:
+                return _coerce_str_object_dict(store.get("side_channel_timeout_by_purpose"))
+
+            def _apply_side_channel_timeout_by_purpose(val: dict[str, object]) -> None:
+                mgr.set_timeout_overrides(val)
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_timeout_by_purpose,
+                    _apply_side_channel_timeout_by_purpose,
+                    fire_immediately=True,
+                )
+            )
+
+            def _select_side_channel_budget_caps() -> dict[str, object]:
+                return _coerce_str_object_dict(store.get("side_channel_budget_caps"))
+
+            def _apply_side_channel_budget_caps(val: dict[str, object]) -> None:
+                mgr.set_budget_caps(val)
+
+            disposers.append(
+                reaction(
+                    _select_side_channel_budget_caps,
+                    _apply_side_channel_budget_caps,
+                    fire_immediately=True,
+                )
+            )
 
         tmux = context.get("tmux_controller")
         if tmux is not None:
-            disposers.append(reaction(
-                lambda: store.get("auto_zoom_default"),
-                lambda val, t=tmux: setattr(t, "auto_zoom", val),
-                fire_immediately=True,
-            ))
+            def _select_auto_zoom_default() -> bool:
+                return bool(store.get("auto_zoom_default"))
+
+            def _apply_auto_zoom_default(val: bool) -> None:
+                tmux.auto_zoom = val
+
+            disposers.append(
+                reaction(
+                    _select_auto_zoom_default,
+                    _apply_auto_zoom_default,
+                    fire_immediately=True,
+                )
+            )
 
     return disposers
 

--- a/src/cc_dump/experiments/perf_metrics.py
+++ b/src/cc_dump/experiments/perf_metrics.py
@@ -19,7 +19,7 @@ Usage:
 """
 
 import time
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 
 
 @dataclass

--- a/src/cc_dump/io/perf_logging.py
+++ b/src/cc_dump/io/perf_logging.py
@@ -13,7 +13,6 @@ import time
 import traceback
 from collections.abc import Callable, Mapping
 from contextlib import contextmanager
-from typing import Any
 
 
 _enabled = True
@@ -45,8 +44,8 @@ def _threshold_for(stage: str) -> float:
 
 
 def _resolve_context(
-    context: Mapping[str, Any] | Callable[[], Mapping[str, Any]] | None,
-) -> Mapping[str, Any]:
+    context: Mapping[str, object] | Callable[[], Mapping[str, object]] | None,
+) -> Mapping[str, object]:
     if context is None:
         return {}
     if callable(context):
@@ -58,7 +57,7 @@ def _resolve_context(
     return context
 
 
-def _format_context(context: Mapping[str, Any]) -> str:
+def _format_context(context: Mapping[str, object]) -> str:
     # [LAW:dataflow-not-control-flow] Context serialization is data-driven (sorted keys).
     parts = [f"{k}={context[k]!r}" for k in sorted(context.keys())]
     return " ".join(parts)
@@ -79,7 +78,7 @@ def monitor_slow_path(
     stage: str,
     *,
     logger: logging.Logger,
-    context: Mapping[str, Any] | Callable[[], Mapping[str, Any]] | None = None,
+    context: Mapping[str, object] | Callable[[], Mapping[str, object]] | None = None,
     threshold_ms: float | None = None,
 ):
     """Log stack diagnostics when a stage exceeds its latency threshold."""

--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -1469,7 +1469,7 @@ class CcDumpApp(App):
         return _side_channel.get_side_channel_panel_widget(self)
 
     def _parse_qa_scope(self, draft, *, total_messages: int) -> tuple[cc_dump.ai.conversation_qa.QAScope, str]:
-        return _side_channel.parse_qa_scope(self, draft, total_messages=total_messages)
+        return _side_channel.parse_qa_scope(draft, total_messages=total_messages)
 
     def _render_qa_result_text(
         self,

--- a/src/cc_dump/tui/dump_formatting.py
+++ b/src/cc_dump/tui/dump_formatting.py
@@ -7,16 +7,16 @@ Hot-reloadable: this module has zero app/widget dependencies.
 """
 
 from collections.abc import Callable
-from typing import Any, TextIO
+from typing import TextIO
 
 import cc_dump.core.formatting as fmt
 from cc_dump.core.analysis import fmt_tokens
 
 
-BlockWriter = Callable[[TextIO, Any], None]
+BlockWriter = Callable[[TextIO, object], None]
 
 
-def _write_header(f: TextIO, block: Any, block_idx: int) -> None:
+def _write_header(f: TextIO, block: object, block_idx: int) -> None:
     block_type = type(block).__name__
     f.write(f"  [{block_idx}] {block_type}\n")
     f.write(f"  {'-' * 76}\n")
@@ -195,7 +195,7 @@ def _write_newline_block(f: TextIO, block: fmt.NewlineBlock) -> None:
 
 
 # // [LAW:one-source-of-truth] Block type dispatch is defined exactly once.
-BLOCK_WRITERS: dict[type[Any], BlockWriter] = {
+BLOCK_WRITERS: dict[type[object], BlockWriter] = {
     fmt.HeaderBlock: _write_header_block,
     fmt.HttpHeadersBlock: _write_http_headers_block,
     fmt.MetadataBlock: _write_metadata_block,

--- a/src/cc_dump/tui/panel_renderers.py
+++ b/src/cc_dump/tui/panel_renderers.py
@@ -7,8 +7,8 @@ so it can be hot-reloaded without affecting the live widget instances.
 import cc_dump.core.analysis
 import cc_dump.core.palette
 import cc_dump.tui.input_modes
-from rich.text import Text
 from collections.abc import Callable
+from rich.text import Text
 
 # [LAW:one-source-of-truth] Shared compact token formatter lives in analysis.py.
 _fmt_tokens = cc_dump.core.analysis.fmt_tokens
@@ -183,11 +183,11 @@ def render_analytics_models(snapshot: dict) -> str:
 
 
 # [LAW:dataflow-not-control-flow] Mode-to-renderer dispatch for unified analytics dashboard.
-_ANALYTICS_VIEW_RENDERERS = {
+_ANALYTICS_VIEW_RENDERERS: dict[str, Callable[[dict], str]] = {
     "summary": render_analytics_summary,
     "timeline": render_analytics_timeline,
     "models": render_analytics_models,
-}  # type: dict[str, Callable[[dict], str]]
+}
 
 
 def render_analytics_panel(snapshot: dict, view_mode: str) -> str:

--- a/src/cc_dump/tui/rendering_impl.py
+++ b/src/cc_dump/tui/rendering_impl.py
@@ -848,7 +848,7 @@ def _render_metadata_summary_expanded(block: MetadataBlock) -> Text | None:
     return t
 
 
-def _render_metadata_full_expanded(block: MetadataBlock) -> Text | None:
+def _render_metadata_full_expanded(block: MetadataBlock) -> ConsoleRenderable | None:
     """Full-expanded metadata renderer with full identity values."""
     base = _render_metadata(block)
     if base is None:
@@ -3927,7 +3927,7 @@ def _render_standard_block_strips(
     cache = _block_cache(ctx)
     if cache is not None and cache_key in cache:
         cached = cache[cache_key]
-        return cached[0] if isinstance(cached, tuple) else cached
+        return cached if isinstance(cached, list) else []
 
     segments = ctx.console.render(renderable, ctx.render_options)
     lines = list(Segment.split_lines(segments))

--- a/src/cc_dump/tui/search.py
+++ b/src/cc_dump/tui/search.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 import re
 from collections import OrderedDict
 from collections.abc import Iterable
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum, IntFlag
 from typing import Callable
 

--- a/src/cc_dump/tui/settings_panel.py
+++ b/src/cc_dump/tui/settings_panel.py
@@ -20,6 +20,7 @@ from textual.containers import Horizontal, VerticalScroll
 from textual.message import Message
 from textual.widgets import Input, Label, Select, Static
 
+import cc_dump.app.settings_store
 from cc_dump.tui.chip import ToggleChip
 
 import cc_dump.core.palette
@@ -41,8 +42,6 @@ class FieldDef:
 
 # ─── Field registry ──────────────────────────────────────────────────────────
 # // [LAW:one-source-of-truth] Defaults from settings_store.SCHEMA.
-
-import cc_dump.app.settings_store
 
 SETTINGS_FIELDS: list[FieldDef] = [
     FieldDef(

--- a/src/cc_dump/tui/widget_factory.py
+++ b/src/cc_dump/tui/widget_factory.py
@@ -9,8 +9,6 @@ import hashlib
 import json
 import logging
 import os
-import sys
-import traceback
 from contextlib import contextmanager
 from collections import deque
 from dataclasses import dataclass, field
@@ -23,7 +21,6 @@ from textual.strip import Strip
 from textual.cache import LRUCache
 from textual.geometry import Size, Offset
 from rich.segment import Segment
-from rich.style import Style
 from rich.text import Text
 
 # Use module-level imports for hot-reload


### PR DESCRIPTION
## Summary

### src/cc_dump/ai
- Added `_coerce_int` in `side_channel.py` and used it in timeout/budget setter normalization to avoid unsafe `int(object)` calls.

### src/cc_dump/app
- Added `SideChannelPurposeSummaryRow` `TypedDict` in `analytics_store.py` and tightened purpose-summary aggregation typing.
- Reworked `settings_store.py` reaction selectors into typed selector/apply helpers, added `_coerce_int` and `_coerce_str_object_dict`, and preserved existing runtime behavior.

### src/cc_dump/io
- Replaced explicit `Any` in `perf_logging.py` context types with `object`-based mappings.

### src/cc_dump/tui
- Fixed side-channel wrapper call in `app.py` to match `parse_qa_scope` signature.
- Broadened `rendering_impl.py` metadata full-expanded return type to `ConsoleRenderable | None` and corrected cache return typing for strip rendering.
- Replaced explicit `Any` in `dump_formatting.py` block writer types with `object`.
- Fixed import ordering and unused imports in `settings_panel.py`, `widget_factory.py`, `search.py`, and `panel_renderers.py`.
- Added explicit typed analytics renderer dispatch map in `panel_renderers.py` for mypy-safe calls.

### src/cc_dump/experiments
- Removed unused `field` import in `perf_metrics.py`.

## Removed Functionality
- None.

## Non-product files
- None.

## Validation
- `just lint`
