### PR TITLE
Fix mypy changed-files lint in side-channel scope delegate

### DIFF
--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -1469,7 +1469,7 @@ class CcDumpApp(App):
         return _side_channel.get_side_channel_panel_widget(self)
 
     def _parse_qa_scope(self, draft, *, total_messages: int) -> tuple[cc_dump.ai.conversation_qa.QAScope, str]:
-        return _side_channel.parse_qa_scope(self, draft, total_messages=total_messages)
+        return _side_channel.parse_qa_scope(draft, total_messages=total_messages)
 
     def _render_qa_result_text(
         self,


### PR DESCRIPTION
## Summary
- `src/cc_dump/tui/app.py`: fix `_parse_qa_scope` delegate call to `side_channel_controller.parse_qa_scope(...)` by passing only the draft object plus `total_messages`
- remove accidental extra positional argument (`self`) that caused changed-file mypy lint failure

## Removed Behavior
- Removed invalid call shape that passed duplicate argument values to `parse_qa_scope`

## Non-product files
- None

## Validation
- `uv run python .github/scripts/mypy_changed_files.py`
- `uv run python scripts/quality_gate.py check`
- `uv run ruff check src/cc_dump/tui/app.py`
