### PR TITLE
Address review threads from complexity hotspot PR

### DIFF
--- a/src/cc_dump/tui/side_channel_controller.py
+++ b/src/cc_dump/tui/side_channel_controller.py
@@ -705,12 +705,14 @@ def _resolve_action_review_inputs(
 ) -> tuple[object, tuple[int, ...], tuple[int, ...], str]:
     draft = panel.read_action_review_draft()
     accept_indices, reject_indices, parse_error = _review_parse_indices(app, draft)
+    if parse_error:
+        return (draft, accept_indices, reject_indices, parse_error)
     validation_error = _review_validate_indices(
         items=items,
         accept_indices=accept_indices,
         reject_indices=reject_indices,
     )
-    return (draft, accept_indices, reject_indices, parse_error or validation_error)
+    return (draft, accept_indices, reject_indices, validation_error)
 
 
 def _item_ids_at_indices(items: list[object], indices: tuple[int, ...]) -> list[str]:

--- a/src/cc_dump/tui/widget_factory.py
+++ b/src/cc_dump/tui/widget_factory.py
@@ -499,7 +499,7 @@ class ConversationView(ScrollView):
         strip: Strip,
         selection: Selection | None,
     ) -> None:
-        # [LAW:dataflow-not-control-flow] Selection value decides cache write payload; cache path always executes.
+        # [LAW:dataflow-not-control-flow] Selection disables cache writes to avoid persisting transient highlighting.
         if selection is not None:
             return
         self._line_cache[cache_key] = strip
@@ -1052,7 +1052,6 @@ class ConversationView(ScrollView):
         self._turns.clear()
         self._scroll_anchor = None
         self._reset_background_rerender_state()
-        self._clear_line_cache()
         self._recalculate_offsets()
         if self.is_attached:
             self.refresh()


### PR DESCRIPTION
## Summary
- Update `_record_line_cache_key` comment in `widget_factory.py` to accurately describe cache-write behavior when selection is active.
- Remove redundant `_clear_line_cache()` call from `_prune_all_turns()` in `widget_factory.py`; `_recalculate_offsets()` already clears cache via `_invalidate_cache_for_turns(0, ...)`.
- In `side_channel_controller.py`, make `_resolve_action_review_inputs()` return early on parse errors before running index validation.

## Why
These are direct follow-ups to Copilot review comments on merged PR #45.

## Validation
- `uv run ruff check src/cc_dump/tui/widget_factory.py src/cc_dump/tui/side_channel_controller.py`
- `python3 -m py_compile src/cc_dump/tui/widget_factory.py src/cc_dump/tui/side_channel_controller.py`
- `uv run pytest tests/test_widget_arch.py tests/test_side_channel_panel_integration.py tests/test_textual_panels.py tests/test_view_store_reaction_binding.py`
