### PR TITLE
fix: follow up on hot-reload alias review threads

### DIFF
--- a/src/cc_dump/app/hot_reload.py
+++ b/src/cc_dump/app/hot_reload.py
@@ -219,7 +219,7 @@ def _is_alias_refreshable_export(module_name: str, value: object) -> bool:
     """True when an export is safe and meaningful for alias refresh mapping.
 
     Restricting to module-owned symbols prevents accidental global rebinding caused
-    by interned/shared primitive identities (for example int/str/None singletons).
+    by shared primitive identities from interning/caching (for example int/str/None).
     """
     if isinstance(value, str | bytes | int | float | complex | bool | tuple | frozenset | list | dict | set | type(None)):
         return False

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -6,6 +6,7 @@ Import validation, widget protocols, state preservation, and module structure.
 
 import ast
 import importlib
+import sys
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import AsyncMock, patch
@@ -285,15 +286,17 @@ class TestImportValidation:
         provider_name = "cc_dump._hr_test_provider_primitives"
         consumer_name = "cc_dump._hr_test_consumer_primitives"
         unrelated_name = "cc_dump._hr_test_unrelated_primitives"
+        original_token = sys.intern("cc_dump_hr_test_token")
+        replacement_token = sys.intern("cc_dump_hr_test_token_reloaded")
 
         provider = ModuleType(provider_name)
-        provider.count = 1
+        provider.count = original_token
 
         consumer = ModuleType(consumer_name)
         consumer.count = provider.count
 
         unrelated = ModuleType(unrelated_name)
-        unrelated.also_count = 1
+        unrelated.also_count = original_token
 
         with patch.dict(
             "sys.modules",
@@ -306,14 +309,16 @@ class TestImportValidation:
         ):
             with patch.object(hr, "_RELOAD_ORDER", [provider_name]):
                 with patch.object(importlib, "reload") as mock_reload:
-                    mock_reload.side_effect = lambda mod: setattr(mod, "count", 2) or mod
+                    mock_reload.side_effect = (
+                        lambda mod: setattr(mod, "count", replacement_token) or mod
+                    )
                     reloaded = hr.check_and_get_reloaded()
 
         assert reloaded == [provider_name]
         # Primitive exports are intentionally excluded from alias refresh.
-        assert consumer.count == 1
-        assert unrelated.also_count == 1
-        assert provider.count == 2
+        assert consumer.count is original_token
+        assert unrelated.also_count is original_token
+        assert provider.count is replacement_token
 
     def test_hot_reload_applies_alias_replacements_when_new_value_is_none(self):
         import cc_dump.app.hot_reload as hr


### PR DESCRIPTION
## Summary
Follow-up to unresolved review threads in #57:
- https://github.com/brandon-fryslie/cc-dump/pull/57#discussion_r2883667932
- https://github.com/brandon-fryslie/cc-dump/pull/57#discussion_r2883668003

## Behavior Changes
### `src/cc_dump/app`
- `hot_reload._snapshot_reloaded_exports` now snapshots only module-owned, alias-refreshable symbols.
- Primitive/container exports (`int`, `str`, `None`, lists/dicts/sets, etc.) are excluded from alias replacement mapping to avoid accidental cross-module rebinding via shared/interned object identity.
- `hot_reload._apply_alias_replacements` now applies replacements by key membership (`id(value) in replacements`) so legitimate replacements to `None` are propagated.

### `tests/`
- Updated alias-refresh test fixtures so exported test functions carry the provider module identity.
- Added regression test proving primitive exports are not used for global alias rebinding.
- Added regression test proving alias replacement works when the reloaded value becomes `None`.

## Removed Features
- None.

## Non-product files
- None.

## Validation
- `uv run pytest tests/test_hot_reload.py -q`
- `uv run mypy src/cc_dump/app/hot_reload.py`
- `uv run ruff check src/cc_dump/app/hot_reload.py tests/test_hot_reload.py`
