### PR TITLE
Remove dead saved filterset code

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,9 @@ When running inside tmux with `libtmux` installed:
 
 ### Filterset Presets
 
-Save and recall visibility configurations:
+Apply and cycle built-in visibility presets:
 
 - `F1`–`F9` — Apply a filterset preset (F3 reserved)
-- `Shift+F1`–`Shift+F9` — Save current visibility state to a slot
 - `=` / `-` — Cycle forward/backward through presets
 
 **Built-in defaults:**
@@ -199,8 +198,6 @@ Save and recall visibility configurations:
 | F7 | Full Debug | Everything at full |
 | F8 | Assistant | Assistant only at full |
 | F9 | Minimal | User + assistant + tools at summary |
-
-User-saved filtersets override built-in defaults for the same slot.
 
 ### Theme Cycling
 
@@ -286,7 +283,6 @@ Each press cycles: current → next visibility level.
 | Key | Action |
 |-----|--------|
 | `F1`–`F9` | Apply preset (F3 skipped) |
-| `Shift+F1`–`Shift+F9` | Save current state to slot |
 | `=` / `-` | Cycle forward / backward through presets |
 
 ### Theme
@@ -315,7 +311,7 @@ Each press cycles: current → next visibility level.
 | Path | Contents |
 |------|----------|
 | `~/.local/share/cc-dump/recordings/` | HAR recordings (flat directory; provider encoded in filename) |
-| `~/.config/cc-dump/settings.json` | Persisted settings (filtersets, theme) |
+| `~/.config/cc-dump/settings.json` | Persisted app settings (theme, launch configs, defaults) |
 
 ## Environment Variables
 

--- a/src/cc_dump/io/settings.py
+++ b/src/cc_dump/io/settings.py
@@ -8,7 +8,6 @@ Import as: import cc_dump.io.settings
 """
 
 import json
-import logging
 import os
 import tempfile
 from pathlib import Path
@@ -99,20 +98,7 @@ DEFAULT_FILTERSETS: dict[str, dict[str, VisState]] = {
 }
 
 
-# [LAW:one-source-of-truth] Valid category keys derived from defaults
-_VALID_CATEGORY_KEYS = frozenset(next(iter(DEFAULT_FILTERSETS.values())).keys())
-
-
 def get_filterset(slot: str) -> Optional[dict[str, VisState]]:
-    """Return built-in filterset for slot. Logs warning if stale saved data exists."""
-    # Check for stale saved data and log clearly
-    saved = load_settings().get("filtersets", {}).get(slot)
-    if saved is not None:
-        saved_keys = {k for k, v in saved.items() if isinstance(v, list) and len(v) == 3}
-        if saved_keys != _VALID_CATEGORY_KEYS:
-            logging.getLogger(__name__).warning(
-                "Ignoring stale filterset slot %s: expected keys %s, got %s",
-                slot, sorted(_VALID_CATEGORY_KEYS), sorted(saved_keys),
-            )
-    # [LAW:one-source-of-truth] Always return built-in defaults
+    """Return the built-in filterset for a slot."""
+    # [LAW:one-source-of-truth] Filterset slots are defined only by built-in defaults.
     return DEFAULT_FILTERSETS.get(slot)

--- a/src/cc_dump/tui/action_handlers.py
+++ b/src/cc_dump/tui/action_handlers.py
@@ -217,7 +217,7 @@ def prev_filterset(app) -> None:
 
 
 def apply_filterset(app, slot: str) -> None:
-    """Apply a saved filterset slot to the current visibility state."""
+    """Apply a built-in filterset slot to the current visibility state."""
     filters = cc_dump.io.settings.get_filterset(slot)
     if filters is None:
         app.notify(f"Preset F{slot} is empty", severity="warning")
@@ -230,7 +230,7 @@ def apply_filterset(app, slot: str) -> None:
         updates[f"exp:{name}"] = vs.expanded
     app._view_store.update(updates)
     app._view_store.set("filter:active", slot)
-    # Show name for built-in presets, just slot number for user-defined
+    # [LAW:one-source-of-truth] Filterset labels come from built-in slot names only.
     name = cc_dump.tui.action_config.FILTERSET_NAMES.get(slot, "")
     label = f"F{slot} {name}" if name else f"F{slot}"
     app.notify(label)

--- a/tests/test_settings_filterset.py
+++ b/tests/test_settings_filterset.py
@@ -1,14 +1,6 @@
-"""Unit tests for settings.get_filterset() defensive validation."""
+"""Unit tests for built-in filterset presets."""
 
-import json
-import logging
-
-
-from cc_dump.io.settings import (
-    DEFAULT_FILTERSETS,
-    _VALID_CATEGORY_KEYS,
-    get_filterset,
-)
+from cc_dump.io.settings import DEFAULT_FILTERSETS, get_filterset
 
 
 def test_get_filterset_returns_defaults():
@@ -23,66 +15,8 @@ def test_get_filterset_unknown_slot_returns_none():
     assert get_filterset("99") is None
 
 
-def test_get_filterset_stale_data_logs_warning(tmp_path, monkeypatch, caplog):
-    """Stale saved data with wrong keys produces a warning and returns defaults."""
-    # Write a settings file with stale category keys (old schema)
-    settings_path = tmp_path / "cc-dump" / "settings.json"
-    settings_path.parent.mkdir(parents=True)
-    stale_data = {
-        "filtersets": {
-            "1": {
-                "headers": [True, False, False],
-                "budget": [True, False, False],
-                "user": [True, True, False],
-            }
-        }
-    }
-    settings_path.write_text(json.dumps(stale_data), encoding="utf-8")
-
-    # Point get_config_path to our tmp settings
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    with caplog.at_level(logging.WARNING, logger="cc_dump.io.settings"):
-        result = get_filterset("1")
-
-    # Should return defaults, not stale data
-    assert result == DEFAULT_FILTERSETS["1"]
-
-    # Should have logged a warning about mismatched keys
-    assert any("stale filterset slot 1" in r.message.lower() for r in caplog.records), (
-        f"Expected stale warning, got: {[r.message for r in caplog.records]}"
-    )
-
-
-def test_get_filterset_matching_saved_data_no_warning(tmp_path, monkeypatch, caplog):
-    """Saved data with correct keys does NOT produce a warning."""
-    # Write a settings file with correct category keys
-    settings_path = tmp_path / "cc-dump" / "settings.json"
-    settings_path.parent.mkdir(parents=True)
-    correct_data = {
-        "filtersets": {
-            "1": {k: [True, True, False] for k in _VALID_CATEGORY_KEYS}
-        }
-    }
-    settings_path.write_text(json.dumps(correct_data), encoding="utf-8")
-
-    monkeypatch.setenv("XDG_CONFIG_HOME", str(tmp_path))
-
-    with caplog.at_level(logging.WARNING, logger="cc_dump.io.settings"):
-        result = get_filterset("1")
-
-    # Should return defaults (we always return defaults now)
-    assert result == DEFAULT_FILTERSETS["1"]
-
-    # Should NOT have logged any warnings
-    assert not any("stale" in r.message.lower() for r in caplog.records), (
-        f"Unexpected warning: {[r.message for r in caplog.records]}"
-    )
-
-
-def test_valid_category_keys_match_defaults():
-    """_VALID_CATEGORY_KEYS matches all DEFAULT_FILTERSETS slot keys."""
-    for slot, filters in DEFAULT_FILTERSETS.items():
-        assert set(filters.keys()) == _VALID_CATEGORY_KEYS, (
-            f"slot {slot} keys don't match _VALID_CATEGORY_KEYS"
-        )
+def test_filterset_slots_share_the_same_category_keys():
+    """All built-in presets cover the same category set."""
+    slot_keys = [set(filters.keys()) for filters in DEFAULT_FILTERSETS.values()]
+    assert slot_keys, "expected at least one built-in filterset"
+    assert all(keys == slot_keys[0] for keys in slot_keys[1:])


### PR DESCRIPTION
## Summary

- `src/cc_dump/io`: remove the dead persisted-filterset validation path from `get_filterset()` so filterset slots resolve only from built-in defaults.
- `src/cc_dump/tui`: update filterset action wording to reflect built-in presets only.
- `tests/`: delete tests that only exercised the removed stale-saved-filterset warning path and keep coverage on the live built-in preset contract.
- `README.md`: remove documentation for nonexistent `Shift+F1`-`Shift+F9` save behavior and the claim that user-saved presets override built-ins.

## Removed Behavior

- Removed the dead code path that read `settings.json["filtersets"]`, validated saved filterset keys, logged a stale-data warning, and then ignored the result.
- Removed documentation for the nonexistent saved filterset feature.

## Non-product files

- None.

## Validation

- `uv run python scripts/quality_gate.py check`
- `uv run mypy src/`
- `uv run pytest tests/test_settings_filterset.py tests/test_textual_visibility.py`