### PR TITLE
Simplify and type multi-provider proxy endpoints

### DIFF
--- a/src/cc_dump/app/launch_config.py
+++ b/src/cc_dump/app/launch_config.py
@@ -17,6 +17,7 @@ from typing import Literal
 
 import cc_dump.app.launcher_registry
 import cc_dump.io.settings
+import cc_dump.providers
 
 
 SHELL_OPTIONS = ("", "bash", "zsh")
@@ -413,7 +414,7 @@ def _derive_process_names(config: LaunchConfig) -> tuple[str, ...]:
 
 def build_launch_profile(
     config: LaunchConfig,
-    provider_endpoints: dict[str, dict[str, object]] | None = None,
+    provider_endpoints: cc_dump.providers.ProviderEndpointMap | None = None,
     session_id: str = "",
 ) -> LaunchProfile:
     """Build runtime launch profile for tmux.

--- a/src/cc_dump/app/launcher_registry.py
+++ b/src/cc_dump/app/launcher_registry.py
@@ -34,7 +34,7 @@ _LAUNCHERS: dict[str, LauncherSpec] = {
         display_name="Claude",
         default_command="claude",
         process_names=("claude", "clod"),
-        provider_key="anthropic",
+        provider_key=cc_dump.providers.DEFAULT_PROVIDER_KEY,
         supports_model_flag=True,
         supports_resume_flag=True,
     ),
@@ -70,7 +70,7 @@ def launcher_keys() -> tuple[str, ...]:
 
 def build_proxy_env(
     spec: LauncherSpec,
-    provider_endpoints: dict[str, dict[str, object]] | None,
+    provider_endpoints: cc_dump.providers.ProviderEndpointMap | None,
 ) -> dict[str, str]:
     """Build environment mapping for launcher from available proxy endpoints.
 
@@ -81,22 +81,6 @@ def build_proxy_env(
         return {}
 
     endpoint = provider_endpoints.get(spec.provider_key)
-    if not isinstance(endpoint, dict):
+    if endpoint is None:
         return {}
-
-    proxy_url = str(endpoint.get("proxy_url", "") or "").strip()
-    if not proxy_url:
-        return {}
-
-    provider = cc_dump.providers.get_provider_spec(spec.provider_key)
-    if provider.proxy_type == "forward":
-        forward_ca_cert_path = str(endpoint.get("forward_proxy_ca_cert_path", "") or "").strip()
-        forward_env = {
-            "HTTP_PROXY": proxy_url,
-            "HTTPS_PROXY": proxy_url,
-        }
-        if forward_ca_cert_path:
-            forward_env["NODE_EXTRA_CA_CERTS"] = forward_ca_cert_path
-        return forward_env
-
-    return {provider.base_url_env: proxy_url}
+    return cc_dump.providers.build_provider_proxy_env(endpoint)

--- a/src/cc_dump/cli.py
+++ b/src/cc_dump/cli.py
@@ -10,6 +10,7 @@ import signal
 import sys
 import threading
 import uuid
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
 
@@ -116,6 +117,20 @@ def _recording_path_for_provider(recordings_dir: Path, provider: str, timestamp:
     return str(recordings_dir / filename)
 
 
+@dataclass(frozen=True)
+class ProviderProxyBinding:
+    """Runtime proxy binding for one provider.
+
+    // [LAW:one-type-per-behavior] One binding type owns server, handler, and endpoint state.
+    """
+
+    spec: cc_dump.providers.ProviderSpec
+    server: http.server.ThreadingHTTPServer
+    handler_class: type[ProxyHandler]
+    port: int
+    endpoint: cc_dump.providers.ProviderEndpoint
+
+
 def main():
     auto_launch_config, _argv, auto_launch_extra_args = _detect_run_subcommand(sys.argv[1:])
 
@@ -127,7 +142,12 @@ def main():
         ),
         formatter_class=argparse.RawDescriptionHelpFormatter,
     )
-    target = os.environ.get("ANTHROPIC_BASE_URL", "https://api.anthropic.com")
+    default_provider_key = cc_dump.providers.DEFAULT_PROVIDER_KEY
+    default_provider_spec = cc_dump.providers.require_provider_spec(default_provider_key)
+    target = os.environ.get(
+        default_provider_spec.base_url_env,
+        default_provider_spec.default_target,
+    )
     parser.add_argument(
         "--host",
         type=str,
@@ -139,7 +159,10 @@ def main():
         "--target",
         type=str,
         default=target,
-        help="Upstream API URL for reverse proxy mode (default: https://api.anthropic.com)",
+        help=(
+            "Upstream API URL for reverse proxy mode "
+            f"(default: {default_provider_spec.default_target})"
+        ),
     )
     parser.add_argument(
         "--record", type=str, default=None, help="HAR recording output directory"
@@ -318,15 +341,8 @@ def main():
         t.start()
         return srv, ap, t
 
-    proxy_servers: dict[str, http.server.ThreadingHTTPServer] = {}
-    # // [LAW:one-source-of-truth] Handler classes keyed by provider for shared runtime wiring.
-    proxy_handlers: dict[str, type[ProxyHandler]] = {}
-    proxy_ports: dict[str, int] = {}
-    proxy_targets: dict[str, str | None] = {}
-    provider_endpoints: dict[str, dict[str, str]] = {}
-
     active_specs: list[cc_dump.providers.ProviderSpec] = [
-        cc_dump.providers.require_provider_spec(cc_dump.providers.DEFAULT_PROVIDER_KEY)
+        default_provider_spec
     ]
     active_specs.extend(
         spec
@@ -341,10 +357,14 @@ def main():
         ca_dir = Path(args.forward_proxy_ca_dir) if args.forward_proxy_ca_dir else None
         forward_proxy_ca = ForwardProxyCertificateAuthority(ca_dir=ca_dir)
 
+    bindings: dict[str, ProviderProxyBinding] = {}
     for spec in active_specs:
-        bind_port = args.port if spec.key == cc_dump.providers.DEFAULT_PROVIDER_KEY else int(getattr(args, f"{spec.key}_port"))
-        configured_target = args.target if spec.key == cc_dump.providers.DEFAULT_PROVIDER_KEY else str(getattr(args, f"{spec.key}_target"))
-        target_host = configured_target if spec.proxy_type == "reverse" else None
+        bind_port = args.port if spec.key == default_provider_key else int(getattr(args, f"{spec.key}_port"))
+        configured_target = (
+            args.target if spec.key == default_provider_key else str(getattr(args, f"{spec.key}_target"))
+        )
+        normalized_target = configured_target.rstrip("/") if configured_target else None
+        target_host = normalized_target if spec.proxy_type == "reverse" else None
         ca_for_provider = forward_proxy_ca if spec.proxy_type == "forward" else None
 
         handler = make_handler_class(
@@ -354,37 +374,48 @@ def main():
             forward_proxy_ca=ca_for_provider,
         )
         srv, port, _ = _start_proxy_server(args.host, bind_port, handler)
-        proxy_servers[spec.key] = srv
-        proxy_handlers[spec.key] = handler
-        proxy_ports[spec.key] = port
-        proxy_targets[spec.key] = configured_target.rstrip("/") if configured_target else None
+        endpoint = cc_dump.providers.build_provider_endpoint(
+            spec.key,
+            proxy_url=f"http://{args.host}:{port}",
+            target=normalized_target,
+            proxy_mode=spec.proxy_type,
+            forward_proxy_ca_cert_path=(
+                str(ca_for_provider.ca_cert_path) if ca_for_provider is not None else None
+            ),
+        )
+        bindings[spec.key] = ProviderProxyBinding(
+            spec=spec,
+            server=srv,
+            handler_class=handler,
+            port=port,
+            endpoint=endpoint,
+        )
 
-    actual_port = proxy_ports[cc_dump.providers.DEFAULT_PROVIDER_KEY]
-    anthropic_target = proxy_targets.get(cc_dump.providers.DEFAULT_PROVIDER_KEY)
-    server = proxy_servers[cc_dump.providers.DEFAULT_PROVIDER_KEY]
+    provider_endpoints: cc_dump.providers.ProviderEndpointMap = {
+        provider: binding.endpoint for provider, binding in bindings.items()
+    }
+    default_binding = bindings[default_provider_key]
+    actual_port = default_binding.port
+    default_target = default_binding.endpoint.target
+    server = default_binding.server
 
     print("🚀 cc-dump proxy started")
-    for spec in active_specs:
-        proxy_url = f"http://{args.host}:{proxy_ports[spec.key]}"
-        provider_target = proxy_targets.get(spec.key)
-        print(f"   {spec.display_name} endpoint: {proxy_url}")
-        print(f"     Proxy type: {spec.proxy_type}")
-        if spec.proxy_type == "reverse":
-            if provider_target:
-                print(f"     Target: {provider_target}")
-            print(f"     Usage: {spec.base_url_env}={proxy_url} {spec.client_hint}")
+    for binding in bindings.values():
+        spec = binding.spec
+        endpoint = binding.endpoint
+        print(f"   {spec.display_name} endpoint: {endpoint.proxy_url}")
+        print(f"     Proxy type: {endpoint.proxy_mode}")
+        if endpoint.proxy_mode == "reverse":
+            if endpoint.target:
+                print(f"     Target: {endpoint.target}")
+            print(f"     Usage: {spec.base_url_env}={endpoint.proxy_url} {spec.client_hint}")
         else:
             print(
-                f"     Usage: HTTP_PROXY={proxy_url} HTTPS_PROXY={proxy_url} NODE_EXTRA_CA_CERTS={forward_proxy_ca.ca_cert_path if forward_proxy_ca else ''} {spec.client_hint}"
+                "     Usage: "
+                f"HTTP_PROXY={endpoint.proxy_url} HTTPS_PROXY={endpoint.proxy_url} "
+                f"NODE_EXTRA_CA_CERTS={endpoint.forward_proxy_ca_cert_path or ''} "
+                f"{spec.client_hint}"
             )
-
-        provider_endpoints[spec.key] = {
-            "proxy_url": proxy_url,
-            "target": (provider_target or "") if spec.proxy_type == "reverse" else "",
-            "proxy_mode": spec.proxy_type,
-        }
-        if spec.proxy_type == "forward" and forward_proxy_ca is not None:
-            provider_endpoints[spec.key]["forward_proxy_ca_cert_path"] = str(forward_proxy_ca.ca_cert_path)
 
     # State dict for content tracking (used by formatting layer)
     state = {
@@ -416,7 +447,7 @@ def main():
         recordings_dir = _recordings_output_dir(args.record)
         recordings_dir.mkdir(parents=True, exist_ok=True)
         timestamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%SZ")
-        active_providers = list(proxy_ports.keys())
+        active_providers = list(bindings.keys())
 
         for provider in active_providers:
             record_path = _recording_path_for_provider(recordings_dir, provider, timestamp)
@@ -428,7 +459,10 @@ def main():
             har_recorders.append(recorder)
             router.add_subscriber(DirectSubscriber(recorder.on_event))
             print(f"   Recording ({provider}): {record_path} (created on first API call)")
-        primary_record_path = recording_paths.get("anthropic") or next(iter(recording_paths.values()), None)
+        primary_record_path = recording_paths.get(default_provider_key) or next(
+            iter(recording_paths.values()),
+            None,
+        )
     else:
         print("   Recording: disabled (--no-record)")
 
@@ -473,7 +507,7 @@ def main():
     sc_enabled = bool(settings_store.get("side_channel_enabled"))
     side_channel_mgr = cc_dump.ai.side_channel.SideChannelManager()
     side_channel_mgr.enabled = sc_enabled
-    side_channel_mgr.set_base_url(f"http://{args.host}:{actual_port}")
+    side_channel_mgr.set_base_url(default_binding.endpoint.proxy_url)
 
     def _coerce_token_count(value: object) -> int:
         if isinstance(value, bool):
@@ -512,8 +546,8 @@ def main():
         interceptors=[cc_dump.pipeline.sentinel.make_interceptor(tmux_ctrl)],
     )
     # // [LAW:single-enforcer] One shared request pipeline is applied at every provider handler boundary.
-    for handler_cls in proxy_handlers.values():
-        handler_cls.request_pipeline = pipeline
+    for binding in bindings.values():
+        binding.handler_class.request_pipeline = pipeline
 
     router.start()
 
@@ -546,7 +580,7 @@ def main():
         analytics_store=analytics_store,
         host=args.host,
         port=actual_port,
-        target=anthropic_target,
+        target=default_target,
         replay_data=replay_data,
         recording_path=primary_record_path,
         replay_file=args.replay,
@@ -600,9 +634,10 @@ def main():
             server.server_close()
 
         # Shutdown optional provider servers
-        for provider, srv in proxy_servers.items():
-            if provider == "anthropic":
+        for provider, binding in bindings.items():
+            if provider == default_provider_key:
                 continue
+            srv = binding.server
             shutdown_thread = threading.Thread(target=srv.shutdown, daemon=True)
             shutdown_thread.start()
             try:
@@ -618,8 +653,12 @@ def main():
 
         # Persist UI sidecar next to active HAR (recording path or replay file).
         candidate_record_paths = [
-            recording_paths.get("anthropic"),
-            *[path for provider, path in recording_paths.items() if provider != "anthropic"],
+            recording_paths.get(default_provider_key),
+            *[
+                path
+                for provider, path in recording_paths.items()
+                if provider != default_provider_key
+            ],
         ]
         sidecar_target = next(
             (path for path in candidate_record_paths if path and os.path.exists(path)),

--- a/src/cc_dump/providers.py
+++ b/src/cc_dump/providers.py
@@ -7,7 +7,11 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Literal
+from typing import Literal, TypeAlias
+
+
+ProtocolFamily: TypeAlias = Literal["anthropic", "openai"]
+ProxyMode: TypeAlias = Literal["reverse", "forward"]
 
 
 @dataclass(frozen=True)
@@ -18,15 +22,29 @@ class ProviderSpec:
     display_name: str
     tab_title: str
     tab_short_prefix: str
-    protocol_family: str  # "anthropic" | "openai"
+    protocol_family: ProtocolFamily
     api_paths: tuple[str, ...]
     har_request_url: str
     base_url_env: str
-    proxy_type: Literal["reverse", "forward"]
+    proxy_type: ProxyMode
     default_target: str
     optional_proxy: bool
     url_markers: tuple[str, ...]
     client_hint: str = "<your-tool>"
+
+
+@dataclass(frozen=True)
+class ProviderEndpoint:
+    """Resolved proxy endpoint metadata for one active provider."""
+
+    provider_key: str
+    proxy_url: str
+    target: str | None
+    proxy_mode: ProxyMode
+    forward_proxy_ca_cert_path: str | None = None
+
+
+ProviderEndpointMap: TypeAlias = dict[str, ProviderEndpoint]
 
 
 DEFAULT_PROVIDER_KEY = "anthropic"
@@ -79,6 +97,73 @@ _PROVIDERS: dict[str, ProviderSpec] = {
         url_markers=("api.githubcopilot.com", "githubcopilot.com"),
     ),
 }
+
+
+def _normalize_optional_text(value: object) -> str | None:
+    text = str(value or "").strip()
+    return text or None
+
+
+def _normalize_proxy_mode(value: object, default: ProxyMode) -> ProxyMode:
+    normalized = str(value or default).strip().lower()
+    if normalized == "forward":
+        return "forward"
+    if normalized == "reverse":
+        return "reverse"
+    return default
+
+
+def build_provider_endpoint(
+    provider: str,
+    *,
+    proxy_url: str,
+    target: str | None = None,
+    proxy_mode: ProxyMode | str | None = None,
+    forward_proxy_ca_cert_path: str | None = None,
+) -> ProviderEndpoint:
+    """Build normalized endpoint metadata for one provider.
+
+    // [LAW:single-enforcer] Endpoint normalization lives at this boundary so
+    // CLI, TUI, and launchers consume one typed shape.
+    """
+    spec = require_provider_spec(provider)
+    mode = _normalize_proxy_mode(proxy_mode, spec.proxy_type)
+    normalized_target = _normalize_optional_text(target) if mode == "reverse" else None
+    normalized_ca_path = (
+        _normalize_optional_text(forward_proxy_ca_cert_path) if mode == "forward" else None
+    )
+    return ProviderEndpoint(
+        provider_key=spec.key,
+        proxy_url=str(proxy_url or "").strip(),
+        target=normalized_target,
+        proxy_mode=mode,
+        forward_proxy_ca_cert_path=normalized_ca_path,
+    )
+
+
+def default_provider_endpoint(host: str, port: int, target: str | None = None) -> ProviderEndpoint:
+    """Build endpoint metadata for the canonical default provider."""
+    return build_provider_endpoint(
+        DEFAULT_PROVIDER_KEY,
+        proxy_url=f"http://{host}:{port}",
+        target=target,
+    )
+
+
+def build_provider_proxy_env(endpoint: ProviderEndpoint) -> dict[str, str]:
+    """Build launcher env vars for one provider endpoint."""
+    if not endpoint.proxy_url:
+        return {}
+    spec = require_provider_spec(endpoint.provider_key)
+    if endpoint.proxy_mode == "forward":
+        env = {
+            "HTTP_PROXY": endpoint.proxy_url,
+            "HTTPS_PROXY": endpoint.proxy_url,
+        }
+        if endpoint.forward_proxy_ca_cert_path:
+            env["NODE_EXTRA_CA_CERTS"] = endpoint.forward_proxy_ca_cert_path
+        return env
+    return {spec.base_url_env: endpoint.proxy_url}
 
 
 def normalize_provider(provider: str) -> str:

--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -170,9 +170,7 @@ class CcDumpApp(App):
         view_store=None,
         domain_store=None,
         store_context=None,
-        provider_endpoints: Optional[dict[str, dict[str, object]]] = None,
-        openai_port: Optional[int] = None,
-        openai_target: Optional[str] = None,
+        provider_endpoints: cc_dump.providers.ProviderEndpointMap | None = None,
         auto_launch_config: Optional[str] = None,
         auto_launch_extra_args: Optional[list[str]] = None,
     ):
@@ -188,33 +186,14 @@ class CcDumpApp(App):
         # // [LAW:one-source-of-truth] Active provider endpoints are owned here.
         if provider_endpoints is None:
             provider_endpoints = {
-                "anthropic": {
-                    "proxy_url": "http://{}:{}".format(host, port),
-                    "target": target,
-                },
+                cc_dump.providers.DEFAULT_PROVIDER_KEY: cc_dump.providers.default_provider_endpoint(
+                    host,
+                    port,
+                    target,
+                )
             }
-            if openai_port is not None:
-                provider_endpoints["openai"] = {
-                    "proxy_url": "http://{}:{}".format(host, openai_port),
-                    "target": openai_target,
-                }
-        normalized_endpoints: dict[str, dict[str, object]] = {}
-        for key, data in provider_endpoints.items():
-            if not isinstance(data, dict):
-                continue
-            spec = cc_dump.providers.get_provider_spec(key)
-            normalized: dict[str, object] = {
-                "proxy_url": str(data.get("proxy_url", "") or ""),
-                "target": str(data.get("target", "") or ""),
-            }
-            extras = {
-                extra_key: extra_value
-                for extra_key, extra_value in data.items()
-                if extra_key not in {"proxy_url", "target"}
-            }
-            normalized.update(extras)
-            normalized_endpoints[spec.key] = normalized
-        self._provider_endpoints = normalized_endpoints
+        # // [LAW:single-enforcer] Provider endpoint normalization is centralized in cc_dump.providers.
+        self._provider_endpoints = dict(provider_endpoints)
         self._replay_data = replay_data
         self._recording_path = recording_path
         self._replay_file = replay_file
@@ -903,16 +882,15 @@ class CcDumpApp(App):
 
     def _build_server_info(self) -> dict:
         """// [LAW:one-source-of-truth] All server info derived from constructor params."""
-        anthropic_endpoint = self._provider_endpoints.get(
-            cc_dump.providers.DEFAULT_PROVIDER_KEY,
-            {},
+        default_endpoint = self._provider_endpoints.get(
+            cc_dump.providers.DEFAULT_PROVIDER_KEY
         )
-        proxy_url = str(
-            anthropic_endpoint.get("proxy_url")
-            or "http://{}:{}".format(self._host, self._port)
+        proxy_url = (
+            default_endpoint.proxy_url
+            if default_endpoint is not None and default_endpoint.proxy_url
+            else "http://{}:{}".format(self._host, self._port)
         )
-        primary_target_raw = anthropic_endpoint.get("target", "")
-        primary_target = str(primary_target_raw or "") or None
+        primary_target = default_endpoint.target if default_endpoint is not None else None
         provider_modes: list[str] = []
 
         provider_rows: list[dict[str, str]] = []
@@ -920,16 +898,14 @@ class CcDumpApp(App):
             endpoint = self._provider_endpoints.get(spec.key)
             if endpoint is None:
                 continue
-            mode_hint = str(endpoint.get("proxy_mode", spec.proxy_type) or spec.proxy_type).strip().lower()
-            normalized_mode = mode_hint if mode_hint in {"forward", "reverse"} else spec.proxy_type
-            provider_modes.append(normalized_mode)
+            provider_modes.append(endpoint.proxy_mode)
             provider_rows.append(
                 {
                     "key": spec.key,
                     "name": spec.display_name,
-                    "proxy_url": str(endpoint.get("proxy_url", "") or ""),
-                    "target": str(endpoint.get("target", "") or ""),
-                    "proxy_mode": normalized_mode,
+                    "proxy_url": endpoint.proxy_url,
+                    "target": endpoint.target or "",
+                    "proxy_mode": endpoint.proxy_mode,
                     "base_url_env": spec.base_url_env,
                     "client_hint": spec.client_hint,
                 }

--- a/src/cc_dump/tui/lifecycle_controller.py
+++ b/src/cc_dump/tui/lifecycle_controller.py
@@ -56,46 +56,37 @@ def _connect_stderr_tee(app) -> None:
     tee.connect(_drain)
 
 
-def _endpoint_mode(spec, endpoint: dict[str, object]) -> str:
-    """Return normalized endpoint mode."""
-    raw = endpoint.get("proxy_mode", spec.proxy_type)
-    return str(raw or spec.proxy_type).strip().lower()
-
-
 def _endpoint_usage_line(
     spec,
     *,
-    mode: str,
-    proxy_url: str,
-    target: str,
-    ca_path: str,
+    endpoint: cc_dump.providers.ProviderEndpoint,
 ) -> str:
     """Build provider usage line preserving existing reverse-target behavior."""
-    if mode == "reverse" and target:
-        return f"  Usage: {spec.base_url_env}={proxy_url} {spec.client_hint}"
-    suffix = f" NODE_EXTRA_CA_CERTS={ca_path}" if ca_path else ""
+    if endpoint.proxy_mode == "reverse" and endpoint.target:
+        return f"  Usage: {spec.base_url_env}={endpoint.proxy_url} {spec.client_hint}"
+    suffix = (
+        f" NODE_EXTRA_CA_CERTS={endpoint.forward_proxy_ca_cert_path}"
+        if endpoint.forward_proxy_ca_cert_path
+        else ""
+    )
     return (
-        f"  Usage: HTTP_PROXY={proxy_url} HTTPS_PROXY={proxy_url}{suffix} "
+        f"  Usage: HTTP_PROXY={endpoint.proxy_url} HTTPS_PROXY={endpoint.proxy_url}{suffix} "
         f"{spec.client_hint}"
     )
 
 
-def _endpoint_detail_lines(spec, endpoint: dict[str, object]) -> list[str]:
+def _endpoint_detail_lines(
+    spec,
+    endpoint: cc_dump.providers.ProviderEndpoint,
+) -> list[str]:
     """Return detail lines for one provider endpoint."""
-    proxy_url = str(endpoint.get("proxy_url", "") or "")
-    mode = _endpoint_mode(spec, endpoint)
-    target = str(endpoint.get("target", "") or "")
-    ca_path = str(endpoint.get("forward_proxy_ca_cert_path", "") or "")
-    details = [f"{spec.display_name} endpoint ({mode}): {proxy_url}"]
-    if mode == "reverse" and target:
-        details.append(f"  Target: {target}")
+    details = [f"{spec.display_name} endpoint ({endpoint.proxy_mode}): {endpoint.proxy_url}"]
+    if endpoint.proxy_mode == "reverse" and endpoint.target:
+        details.append(f"  Target: {endpoint.target}")
     details.append(
         _endpoint_usage_line(
             spec,
-            mode=mode,
-            proxy_url=proxy_url,
-            target=target,
-            ca_path=ca_path,
+            endpoint=endpoint,
         )
     )
     return details
@@ -108,8 +99,7 @@ def _log_proxy_endpoints(app) -> None:
         endpoint = app._provider_endpoints.get(spec.key)
         if endpoint is None:
             continue
-        proxy_url = str(endpoint.get("proxy_url", "") or "")
-        if not proxy_url:
+        if not endpoint.proxy_url:
             continue
         # // [LAW:dataflow-not-control-flow] Endpoint logging is derived line data.
         for line in _endpoint_detail_lines(spec, endpoint):

--- a/tests/test_launch_config.py
+++ b/tests/test_launch_config.py
@@ -5,6 +5,7 @@ import json
 import pytest
 
 import cc_dump.app.launcher_registry
+import cc_dump.providers
 from cc_dump.app.launch_config import (
     LaunchConfig,
     build_full_command,
@@ -250,7 +251,11 @@ class TestBuildLaunchProfile:
     def test_profile_sets_provider_env_for_copilot(self):
         config = LaunchConfig(launcher="copilot", command="")
         endpoints = {
-            "copilot": {"proxy_url": "http://127.0.0.1:4567", "target": "https://api.githubcopilot.com"}
+            "copilot": cc_dump.providers.build_provider_endpoint(
+                "copilot",
+                proxy_url="http://127.0.0.1:4567",
+                target="https://api.githubcopilot.com",
+            )
         }
         profile = build_launch_profile(config, provider_endpoints=endpoints, session_id="")
         assert profile.launcher_key == "copilot"
@@ -264,11 +269,12 @@ class TestBuildLaunchProfile:
     def test_profile_sets_forward_proxy_env_for_copilot(self):
         config = LaunchConfig(launcher="copilot", command="")
         endpoints = {
-            "copilot": {
-                "proxy_url": "http://127.0.0.1:4567",
-                "target": "https://api.githubcopilot.com",
-                "forward_proxy_ca_cert_path": "/tmp/forward-ca.crt",
-            }
+            "copilot": cc_dump.providers.build_provider_endpoint(
+                "copilot",
+                proxy_url="http://127.0.0.1:4567",
+                target="https://api.githubcopilot.com",
+                forward_proxy_ca_cert_path="/tmp/forward-ca.crt",
+            )
         }
         profile = build_launch_profile(config, provider_endpoints=endpoints, session_id="")
         assert profile.environment == {
@@ -280,10 +286,11 @@ class TestBuildLaunchProfile:
     def test_profile_sets_reverse_proxy_env_for_claude(self):
         config = LaunchConfig(launcher="claude", command="")
         endpoints = {
-            "anthropic": {
-                "proxy_url": "http://127.0.0.1:3344",
-                "target": "https://api.anthropic.com",
-            }
+            cc_dump.providers.DEFAULT_PROVIDER_KEY: cc_dump.providers.build_provider_endpoint(
+                cc_dump.providers.DEFAULT_PROVIDER_KEY,
+                proxy_url="http://127.0.0.1:3344",
+                target="https://api.anthropic.com",
+            )
         }
         profile = build_launch_profile(config, provider_endpoints=endpoints, session_id="")
         assert profile.environment == {

--- a/tests/test_providers.py
+++ b/tests/test_providers.py
@@ -36,3 +36,27 @@ def test_provider_proxy_type_defaults():
     assert providers.require_provider_spec("anthropic").proxy_type == "reverse"
     assert providers.require_provider_spec("openai").proxy_type == "reverse"
     assert providers.require_provider_spec("copilot").proxy_type == "forward"
+
+
+def test_build_provider_endpoint_normalizes_forward_ca_path():
+    endpoint = providers.build_provider_endpoint(
+        "copilot",
+        proxy_url="http://127.0.0.1:4567",
+        target="https://api.githubcopilot.com",
+        forward_proxy_ca_cert_path=" /tmp/copilot-ca.crt ",
+    )
+    assert endpoint.provider_key == "copilot"
+    assert endpoint.proxy_mode == "forward"
+    assert endpoint.target is None
+    assert endpoint.forward_proxy_ca_cert_path == "/tmp/copilot-ca.crt"
+
+
+def test_build_provider_proxy_env_uses_endpoint_mode():
+    endpoint = providers.build_provider_endpoint(
+        providers.DEFAULT_PROVIDER_KEY,
+        proxy_url="http://127.0.0.1:3344",
+        target="https://api.anthropic.com",
+    )
+    assert providers.build_provider_proxy_env(endpoint) == {
+        "ANTHROPIC_BASE_URL": "http://127.0.0.1:3344",
+    }

--- a/tests/test_settings_launch_controller.py
+++ b/tests/test_settings_launch_controller.py
@@ -1,5 +1,6 @@
 from types import SimpleNamespace
 
+import cc_dump.providers
 import cc_dump.tui.settings_launch_controller as settings_launch
 from cc_dump.app.tmux_controller import LaunchAction, LaunchResult
 
@@ -15,7 +16,7 @@ class _ViewStore:
 class _App:
     def __init__(self, tmux):
         self._tmux_controller = tmux
-        self._provider_endpoints: dict[str, object] = {}
+        self._provider_endpoints: dict[str, cc_dump.providers.ProviderEndpoint] = {}
         self._view_store = _ViewStore()
         self.notifications: list[str] = []
 


### PR DESCRIPTION
## Summary

### `src/cc_dump/providers.py`
- add a typed `ProviderEndpoint` model plus canonical helpers for endpoint normalization and proxy env derivation
- centralize forward-vs-reverse proxy behavior so launcher and TUI layers consume one typed shape instead of nested string-key dicts
- promote `DEFAULT_PROVIDER_KEY` usage as the canonical default-provider reference

### `src/cc_dump/cli.py`
- replace the parallel per-provider runtime dicts (`proxy_servers`, `proxy_handlers`, `proxy_ports`, `proxy_targets`) with one typed `ProviderProxyBinding`
- build provider endpoint metadata once at the proxy boundary and pass that typed map through the rest of the app
- remove hardcoded default-provider string handling in favor of `DEFAULT_PROVIDER_KEY`

### `src/cc_dump/tui/app.py`, `src/cc_dump/tui/lifecycle_controller.py`
- switch TUI provider endpoint handling from ad hoc dict normalization to the typed `ProviderEndpoint` model
- remove the unused `openai_port` / `openai_target` constructor fallback path
- derive info-panel and startup logging output from typed endpoint fields instead of string-key lookups

### `src/cc_dump/app/launcher_registry.py`, `src/cc_dump/app/launch_config.py`
- change launcher proxy environment construction to consume `ProviderEndpointMap`
- reuse the centralized provider helper for reverse and forward proxy env generation

### `tests/`
- update launch-profile and settings-launch tests to use typed provider endpoints
- add provider tests covering endpoint normalization and proxy env derivation

## Removed complexity
- deleted the weakly typed `dict[str, dict[str, ...]]` endpoint contract from this feature path
- deleted the unused `CcDumpApp` `openai_port` / `openai_target` compatibility path
- removed duplicated forward/reverse proxy env logic from launcher code

## Non-product files
- none

## Validation
- `uv run ruff check .`
- `uv run mypy src/cc_dump/providers.py src/cc_dump/cli.py src/cc_dump/tui/app.py src/cc_dump/tui/lifecycle_controller.py src/cc_dump/app/launcher_registry.py src/cc_dump/app/launch_config.py`
- `uv run pytest tests/test_providers.py tests/test_launch_config.py tests/test_settings_launch_controller.py tests/test_ui_state_resume.py tests/test_view_store_reaction_binding.py`
- `uv run python scripts/quality_gate.py check`
