### PR TITLE
refactor: remove system prompt tracking diffs

### DIFF
--- a/src/cc_dump/cli.py
+++ b/src/cc_dump/cli.py
@@ -386,12 +386,8 @@ def main():
         if spec.proxy_type == "forward" and forward_proxy_ca is not None:
             provider_endpoints[spec.key]["forward_proxy_ca_cert_path"] = str(forward_proxy_ca.ca_cert_path)
 
-    # State dict for content tracking (used by formatting layer)
+    # State dict for formatting pipeline coordination.
     state = {
-        "positions": {},
-        "known_hashes": {},
-        "next_id": 0,
-        "next_color": 0,
         "request_counter": 0,
         "current_session": None,  # Track Claude Code session ID for change detection
     }

--- a/src/cc_dump/core/formatting_impl.py
+++ b/src/cc_dump/core/formatting_impl.py
@@ -4,8 +4,6 @@ Returns FormattedBlock dataclasses that can be rendered by different backends
 (e.g., tui/rendering.py for Rich renderables in TUI mode).
 """
 
-import difflib
-import hashlib
 import json
 import re
 from dataclasses import dataclass, field
@@ -28,7 +26,6 @@ from cc_dump.pipeline.event_types import (
 )
 
 from cc_dump.core.analysis import TurnBudget, compute_turn_budget, estimate_tokens, tool_result_breakdown
-from cc_dump.core.palette import TAG_COLOR_COUNT
 import cc_dump.core.segmentation
 import cc_dump.providers
 
@@ -326,19 +323,6 @@ class NewSessionBlock(FormattedBlock):
 
 
 @dataclass
-class TrackedContentBlock(FormattedBlock):
-    """Result of content tracking (new/ref/changed)."""
-
-    status: str = ""  # "new", "ref", "changed"
-    tag_id: str = ""
-    color_idx: int = 0
-    content: str = ""
-    old_content: str = ""
-    new_content: str = ""
-    indent: str = "    "
-
-
-@dataclass
 class TextContentBlock(FormattedBlock):
     """Plain text content."""
 
@@ -528,7 +512,7 @@ class MetadataSection(FormattedBlock):
 class SystemSection(FormattedBlock):
     """Container for the system field from the request body.
 
-    Children: TrackedContentBlock instances.
+    Children: TextContentBlock instances.
     """
 
     children: list[FormattedBlock] = field(default_factory=list)
@@ -587,122 +571,27 @@ class ResponseMetadataSection(FormattedBlock):
 
     children: list[FormattedBlock] = field(default_factory=list)
 
+def _make_system_prompt_children(system: object) -> list[FormattedBlock]:
+    """Return canonical system prompt blocks with no cross-request tracking.
 
-
-# ─── Content tracking (stateful) ─────────────────────────────────────────────
-
-
-def track_content(content, position_key, state, indent="    "):
+    // [LAW:one-source-of-truth] System prompt content is represented once as plain text blocks.
     """
-    Track a content block using the state dict. Returns TrackedContentBlock.
+    # // [LAW:dataflow-not-control-flow] Normalize to a text list, then map every item the same way.
+    if isinstance(system, str):
+        texts = [system] if system else []
+    elif isinstance(system, list):
+        texts = [
+            sblock.get("text", "") if isinstance(sblock, dict) else str(sblock)
+            for sblock in system
+        ]
+        texts = [text for text in texts if text]
+    else:
+        texts = []
 
-    State keys used:
-      positions: pos_key → {hash, content, id, color_idx}
-      known_hashes: hash → id
-      next_id: int
-      next_color: int
-    """
-    h = hashlib.sha256(content.encode()).hexdigest()[:8]
-    positions = state["positions"]
-    known_hashes = state["known_hashes"]
-
-    # Exact content seen before (by hash)
-    if h in known_hashes:
-        color_idx = None
-        for pos in positions.values():
-            if pos["hash"] == h:
-                color_idx = pos["color_idx"]
-                break
-        if color_idx is None:
-            color_idx = state["next_color"] % TAG_COLOR_COUNT
-            state["next_color"] += 1
-        tag_id = known_hashes[h]
-        positions[position_key] = {
-            "hash": h,
-            "content": content,
-            "id": tag_id,
-            "color_idx": color_idx,
-        }
-        # [LAW:one-source-of-truth] content is always the current text;
-        # renderers decide whether to show it or diff metadata.
-        return TrackedContentBlock(
-            status="ref",
-            tag_id=tag_id,
-            color_idx=color_idx,
-            content=content,
-            old_content="",
-            new_content="",
-            indent=indent,
-        )
-
-    # Check if this position had different content before
-    old_pos = positions.get(position_key)
-    if old_pos and old_pos["hash"] != h:
-        color_idx = old_pos["color_idx"]
-        state["next_id"] += 1
-        tag_id = "sp-{}".format(state["next_id"])
-        old_content_val = old_pos["content"]
-        known_hashes[h] = tag_id
-        positions[position_key] = {
-            "hash": h,
-            "content": content,
-            "id": tag_id,
-            "color_idx": color_idx,
-        }
-        # [LAW:one-source-of-truth] content is always the current text;
-        # old_content/new_content carry diff data for SUMMARY renderer.
-        return TrackedContentBlock(
-            status="changed",
-            tag_id=tag_id,
-            color_idx=color_idx,
-            content=content,
-            old_content=old_content_val,
-            new_content=content,
-            indent=indent,
-        )
-
-    # Completely new
-    color_idx = state["next_color"] % TAG_COLOR_COUNT
-    state["next_color"] += 1
-    state["next_id"] += 1
-    tag_id = "sp-{}".format(state["next_id"])
-    known_hashes[h] = tag_id
-    positions[position_key] = {
-        "hash": h,
-        "content": content,
-        "id": tag_id,
-        "color_idx": color_idx,
-    }
-    return TrackedContentBlock(
-        status="new",
-        tag_id=tag_id,
-        color_idx=color_idx,
-        content=content,
-        old_content="",
-        new_content="",
-        indent=indent,
-    )
-
-
-def make_diff_lines(old_text, new_text):
-    """Compute diff lines as (kind, text) tuples.
-
-    kind is one of: "hunk", "add", "remove"
-    """
-    old_lines = old_text.splitlines(keepends=True)
-    new_lines = new_text.splitlines(keepends=True)
-    diff = difflib.unified_diff(old_lines, new_lines, lineterm="", n=2)
-    lines = []
-    for line in diff:
-        if line.startswith("+++") or line.startswith("---"):
-            continue
-        elif line.startswith("@@"):
-            lines.append(("hunk", line.strip()))
-        elif line.startswith("+"):
-            lines.append(("add", line[1:].rstrip()))
-        elif line.startswith("-"):
-            lines.append(("remove", line[1:].rstrip()))
-    return lines
+    return [
+        TextContentBlock(content=text, indent="    ", category=Category.SYSTEM)
+        for text in texts
+    ]
 
 
 # ─── Formatting to structured blocks ─────────────────────────────────────────
@@ -1171,15 +1060,7 @@ def format_request(body, state, request_headers: dict | None = None):
     blocks.append(SeparatorBlock(style="thin"))
 
     # SystemSection container — groups system prompt blocks
-    system = body.get("system", "")
-    system_children: list[FormattedBlock] = []
-    if system:
-        if isinstance(system, str):
-            system_children.append(track_content(system, "system:0", state))
-        elif isinstance(system, list):
-            for i, sblock in enumerate(system):
-                text = sblock.get("text", "") if isinstance(sblock, dict) else str(sblock)
-                system_children.append(track_content(text, "system:{}".format(i), state))
+    system_children = _make_system_prompt_children(body.get("system", ""))
 
     # Emit SystemSection container (always — renderer handles empty children)
     blocks.append(SystemSection(
@@ -1504,12 +1385,14 @@ def format_openai_request(
     blocks.append(SeparatorBlock(style="thin"))
 
     # SystemSection — OpenAI system prompt is messages with role="system"
-    system_children: list[FormattedBlock] = []
-    for msg in messages:
-        if isinstance(msg, dict) and msg.get("role") == "system":
-            content = msg.get("content", "")
-            if isinstance(content, str) and content:
-                system_children.append(track_content(content, "system:0", state))
+    system_children = [
+        TextContentBlock(content=msg.get("content", ""), indent="    ", category=Category.SYSTEM)
+        for msg in messages
+        if isinstance(msg, dict)
+        and msg.get("role") == "system"
+        and isinstance(msg.get("content", ""), str)
+        and msg.get("content", "")
+    ]
 
     blocks.append(SystemSection(
         children=system_children,

--- a/src/cc_dump/tui/dump_formatting.py
+++ b/src/cc_dump/tui/dump_formatting.py
@@ -46,18 +46,6 @@ def _write_metadata_block(f: TextIO, block: fmt.MetadataBlock) -> None:
         f.write(f"  Tool count: {block.tool_count}\n")
 
 
-def _write_tracked_content_block(f: TextIO, block: fmt.TrackedContentBlock) -> None:
-    f.write(f"  Status: {block.status}\n")
-    if block.tag_id:
-        f.write(f"  Tag ID: {block.tag_id}\n")
-    if block.content:
-        f.write(f"  Content: {block.content}\n")
-    if block.old_content:
-        f.write(f"  Old: {block.old_content}\n")
-    if block.new_content:
-        f.write(f"  New: {block.new_content}\n")
-
-
 def _write_text_content_block(f: TextIO, block: fmt.TextContentBlock) -> None:
     if block.content:
         f.write(f"  {block.content}\n")
@@ -199,7 +187,6 @@ BLOCK_WRITERS: dict[type[object], BlockWriter] = {
     fmt.HeaderBlock: _write_header_block,
     fmt.HttpHeadersBlock: _write_http_headers_block,
     fmt.MetadataBlock: _write_metadata_block,
-    fmt.TrackedContentBlock: _write_tracked_content_block,
     fmt.TextContentBlock: _write_text_content_block,
     fmt.ToolUseBlock: _write_tool_use_block,
     fmt.ToolResultBlock: _write_tool_result_block,

--- a/src/cc_dump/tui/rendering_impl.py
+++ b/src/cc_dump/tui/rendering_impl.py
@@ -35,7 +35,6 @@ from cc_dump.core.formatting import (
     HttpHeadersBlock,
     MetadataBlock,
     NewSessionBlock,
-    TrackedContentBlock,
     TextContentBlock,
     ToolUseBlock,
     ToolResultBlock,
@@ -50,7 +49,6 @@ from cc_dump.core.formatting import (
     ProxyErrorBlock,
     NewlineBlock,
     TurnBudgetBlock,
-    make_diff_lines,
     Category,
     VisState,
     ALWAYS_VISIBLE,
@@ -451,7 +449,6 @@ BLOCK_CATEGORY: dict[str, Category | None] = {
     "MetadataBlock": Category.METADATA,
     "NewSessionBlock": Category.METADATA,
     "TurnBudgetBlock": Category.METADATA,
-    "TrackedContentBlock": Category.SYSTEM,
     "ToolUseBlock": Category.TOOLS,
     "ToolResultBlock": Category.TOOLS,
     "ToolUseSummaryBlock": Category.TOOLS,
@@ -929,103 +926,6 @@ def _render_new_session_full_collapsed(block: NewSessionBlock) -> Text | None:
     t.append("═" * 24, style=f"bold {tc.info}")
     return t
 
-
-def _render_tracked_new(
-    block: TrackedContentBlock, tag_style: str
-) -> ConsoleRenderable:
-    """Render a TrackedContentBlock with status='new'."""
-    content_len = len(block.content.splitlines())
-    header = Text(block.indent + "  ")
-    header.append(" {} ".format(block.tag_id), style=tag_style)
-    header.append(" NEW ({} lines):".format(content_len))
-
-    preview = _render_full_collapsed_snippet(block.content, max_lines=5)
-    if preview is None:
-        return header
-    return Group(header, preview)
-
-
-def _render_tracked_ref(block: TrackedContentBlock, tag_style: str) -> Text:
-    """Render a TrackedContentBlock with status='ref'."""
-    t = Text(block.indent + "  ")
-    t.append(" {} ".format(block.tag_id), style=tag_style)
-    t.append(" (unchanged)")
-    return t
-
-
-def _render_tracked_changed(
-    block: TrackedContentBlock, tag_style: str
-) -> ConsoleRenderable:
-    """Render a TrackedContentBlock with status='changed'."""
-    old_len = len(block.old_content.splitlines())
-    new_len = len(block.new_content.splitlines())
-    t = Text(block.indent + "  ")
-    t.append(" {} ".format(block.tag_id), style=tag_style)
-    t.append(" CHANGED ({} -> {} lines):".format(old_len, new_len))
-    diff_lines = make_diff_lines(block.old_content, block.new_content)
-    shown = diff_lines[:5]
-    hidden = max(len(diff_lines) - len(shown), 0)
-    if not shown:
-        return t
-
-    preview = _render_diff(shown, block.indent + "    ")
-    if hidden > 0:
-        preview.append("\n")
-        preview.append(
-            "{}    ··· {} more diff lines".format(block.indent, hidden),
-            style="dim italic",
-        )
-    return Group(t, preview)
-
-
-# [LAW:dataflow-not-control-flow] TrackedContentBlock status dispatch
-_TRACKED_STATUS_RENDERERS = {
-    "new": _render_tracked_new,
-    "ref": _render_tracked_ref,
-    "changed": _render_tracked_changed,
-}
-
-
-def _render_tracked_content_summary(
-    block: TrackedContentBlock,
-) -> ConsoleRenderable | None:
-    """Render a TrackedContentBlock at SUMMARY level — tag colors + diff-aware display."""
-    fg, bg = _tag_styles()[block.color_idx % len(_tag_styles())]
-    tag_style = "bold {} on {}".format(fg, bg)
-
-    renderer = _TRACKED_STATUS_RENDERERS.get(block.status)
-    if renderer:
-        return renderer(block, tag_style)
-    return Text("")
-
-
-def _render_tracked_content_full(
-    block: TrackedContentBlock,
-) -> ConsoleRenderable | None:
-    """Render TrackedContentBlock at FULL level — just the content, like any text block.
-
-    // [LAW:one-source-of-truth] block.content is always the current text.
-    // No status dispatch, no diff, no tag styling — renderers decide presentation.
-    """
-    if not block.content:
-        return None
-    return _render_text_as_markdown(block.content)
-
-
-def _render_tracked_content_full_collapsed(
-    block: TrackedContentBlock,
-) -> ConsoleRenderable | None:
-    """Render TrackedContentBlock at FULL collapsed as title + bounded snippet.
-
-    // [LAW:one-source-of-truth] Snippet is derived from canonical block.content.
-    """
-    title = _render_tracked_content_title(block)
-    preview = _render_full_collapsed_snippet(block.content, max_lines=3)
-    if preview is None:
-        return title
-    return Group(title, preview)
-
-
 def _get_or_segment(block):
     """Lazy segmentation, cached on the block object."""
     if block._segment_result is None:
@@ -1038,7 +938,7 @@ def _render_text_as_markdown(text: str, seg=None) -> ConsoleRenderable:
 
     // [LAW:dataflow-not-control-flow] Dispatch via cc_dump.core.segmentation.SubBlockKind match.
 
-    Extracted from _render_segmented_block to enable reuse for TrackedContentBlock.
+    Extracted from _render_segmented_block to enable reuse across text-like blocks.
     Accepts optional pre-computed segmentation to avoid double work.
     """
 
@@ -2494,52 +2394,6 @@ def _render_turn_budget(block: TurnBudgetBlock) -> Text | None:
 # When absent, BLOCK_RENDERERS output is truncated to TRUNCATION_LIMITS.
 
 
-def _render_tracked_new_title(block: TrackedContentBlock, tag_style: str) -> Text:
-    """Render title for TrackedContentBlock with status='new'."""
-    t = Text(block.indent + "  ")
-    t.append(" {} ".format(block.tag_id), style=tag_style)
-    t.append(" NEW ({} lines)".format(len(block.content.splitlines())))
-    return t
-
-
-def _render_tracked_ref_title(block: TrackedContentBlock, tag_style: str) -> Text:
-    """Render title for TrackedContentBlock with status='ref'."""
-    t = Text(block.indent + "  ")
-    t.append(" {} ".format(block.tag_id), style=tag_style)
-    t.append(" (unchanged)")
-    return t
-
-
-def _render_tracked_changed_title(block: TrackedContentBlock, tag_style: str) -> Text:
-    """Render title for TrackedContentBlock with status='changed'."""
-    t = Text(block.indent + "  ")
-    t.append(" {} ".format(block.tag_id), style=tag_style)
-    t.append(
-        " CHANGED ({} -> {} lines)".format(
-            len(block.old_content.splitlines()), len(block.new_content.splitlines())
-        )
-    )
-    return t
-
-
-# [LAW:dataflow-not-control-flow] TrackedContentBlock title status dispatch
-_TRACKED_STATUS_TITLE_RENDERERS = {
-    "new": _render_tracked_new_title,
-    "ref": _render_tracked_ref_title,
-    "changed": _render_tracked_changed_title,
-}
-
-
-def _render_tracked_content_title(block: TrackedContentBlock) -> Text | None:
-    """Title-only for TrackedContentBlock at EXISTENCE level."""
-    fg, bg = _tag_styles()[block.color_idx % len(_tag_styles())]
-    tag_style = "bold {} on {}".format(fg, bg)
-    renderer = _TRACKED_STATUS_TITLE_RENDERERS.get(block.status)
-    if renderer:
-        return renderer(block, tag_style)
-    return Text(block.indent + "  ")
-
-
 def _render_turn_budget_oneliner(block: TurnBudgetBlock) -> Text | None:
     """One-line context total for TurnBudgetBlock at EXISTENCE level."""
     b = block.budget
@@ -3037,32 +2891,9 @@ def _render_system_section(block: FormattedBlock) -> ConsoleRenderable | None:
 
 
 def _render_system_section_summary_expanded(block: FormattedBlock) -> ConsoleRenderable | None:
-    """Render system section summary-expanded with status composition."""
+    """Render system section summary-expanded with child counts."""
     children = getattr(block, "children", None) or []
-    t = _render_section_with_counts("SYSTEM", children)
-
-    status_counts: Counter[str] = Counter()
-    for child in children:
-        status = getattr(child, "status", "")
-        if isinstance(status, str) and status:
-            status_counts[status] += 1
-    if status_counts:
-        ordered = ["new", "changed", "ref"]
-        parts = [
-            "{}:{}".format(status, status_counts[status])
-            for status in ordered
-            if status_counts.get(status, 0) > 0
-        ]
-        remaining = [
-            "{}:{}".format(status, count)
-            for status, count in sorted(status_counts.items())
-            if status not in ordered
-        ]
-        all_parts = parts + remaining
-        if all_parts:
-            t.append("\n    ", style="dim")
-            t.append("status " + " ".join(all_parts), style="dim")
-    return t
+    return _render_section_with_counts("SYSTEM", children)
 
 
 def _render_system_section_full_collapsed(block: FormattedBlock) -> ConsoleRenderable | None:
@@ -3072,27 +2903,9 @@ def _render_system_section_full_collapsed(block: FormattedBlock) -> ConsoleRende
 
 
 def _render_system_section_full_expanded(block: FormattedBlock) -> ConsoleRenderable | None:
-    """Render system section full-expanded with status and tag previews."""
+    """Render system section full-expanded with child type composition."""
     children = getattr(block, "children", None) or []
-    base = _render_system_section_summary_expanded(block)
-    if not children:
-        return base
-
-    tag_ids = [
-        tag_id
-        for tag_id in (getattr(child, "tag_id", "") for child in children)
-        if isinstance(tag_id, str) and tag_id
-    ]
-    if not tag_ids:
-        return base
-
-    shown = tag_ids[:5]
-    hidden = max(len(tag_ids) - len(shown), 0)
-    detail = Text("    ")
-    detail.append("tags " + ", ".join(shown), style="dim italic")
-    if hidden > 0:
-        detail.append(f" (+{hidden} more)", style="dim italic")
-    return Group(base, detail)
+    return _render_section_with_all_types("SYSTEM", children)
 
 
 def _render_tool_defs_section(block: FormattedBlock) -> ConsoleRenderable | None:
@@ -3363,7 +3176,6 @@ BLOCK_RENDERERS: dict[str, Callable[[FormattedBlock], ConsoleRenderable | None]]
     "MetadataBlock": _render_metadata,
     "NewSessionBlock": _render_new_session,
     "TurnBudgetBlock": _render_turn_budget,
-    "TrackedContentBlock": _render_tracked_content_full,
     "TextContentBlock": _render_text_content,
     "ToolUseBlock": _render_tool_use_full,
     "ToolResultBlock": _render_tool_result_full,
@@ -3455,10 +3267,6 @@ BLOCK_STATE_RENDERERS: dict[
     ("ToolDefsSection", True, True, True): _render_tool_defs_section_full_expanded,
     ("ResponseMetadataSection", True, True, False): _render_response_metadata_section_full_collapsed,
     ("ResponseMetadataSection", True, True, True): _render_response_metadata_section_full_expanded,
-    # TrackedContentBlock: title-only at summary level collapsed, diff-aware at summary expanded
-    ("TrackedContentBlock", True, False, False): _render_tracked_content_title,
-    ("TrackedContentBlock", True, False, True): _render_tracked_content_summary,
-    ("TrackedContentBlock", True, True, False): _render_tracked_content_full_collapsed,
     # HttpHeadersBlock: one-liner at summary level collapsed
     ("HttpHeadersBlock", True, False, False): _render_http_headers_summary,
     ("HttpHeadersBlock", True, False, True): _render_http_headers_summary_expanded,
@@ -4319,29 +4127,6 @@ def combine_rendered_texts(texts: list[Text]) -> Text:
             combined.append("\n")
         combined.append(t)
     return combined
-
-
-# ─── Rendering helpers ─────────────────────────────────────────────────────────
-
-
-def _render_diff(diff_lines: list, indent: str) -> Text:
-    """Render diff lines with color-coded additions/deletions."""
-    tc = get_theme_colors()
-    # [LAW:dataflow-not-control-flow] Diff kind dispatch
-    specs = {
-        "hunk": ("", "dim"),
-        "add": ("+ ", tc.success),
-        "remove": ("- ", tc.error),
-        # // [LAW:locality-or-seam] Legacy support for pre-rename persisted tuples.
-        "del": ("- ", tc.error),
-    }
-    t = Text()
-    for i, (kind, text) in enumerate(diff_lines):
-        if i > 0:
-            t.append("\n")
-        prefix, style = specs.get(kind, ("", ""))
-        t.append(indent + prefix + text, style=style)
-    return t
 
 
 def _indent_text(text: str, indent: str) -> Text:

--- a/src/cc_dump/tui/search.py
+++ b/src/cc_dump/tui/search.py
@@ -258,9 +258,6 @@ _TEXT_EXTRACTORS: dict[str, Callable] = {
     ),
     "MetadataBlock": lambda b: f"model: {b.model} max_tokens: {b.max_tokens}",
     "SystemSection": lambda b: "SYSTEM",
-    "TrackedContentBlock": lambda b: (
-        b.content if b.status == "new" else b.new_content if b.status == "changed" else ""
-    ),
     "MessageBlock": lambda b: f"{b.role} {b.msg_index}",
     "TextContentBlock": lambda b: b.content,
     "ToolUseBlock": lambda b: f"{b.name} {b.detail}",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -233,11 +233,7 @@ def class_proc():
 
 @pytest.fixture
 def fresh_state():
-    """Fresh state dict for content tracking."""
+    """Fresh formatting state dict."""
     return {
-        "positions": {},
-        "known_hashes": {},
-        "next_id": 0,
-        "next_color": 0,
         "request_counter": 0,
     }

--- a/tests/harness/app_runner.py
+++ b/tests/harness/app_runner.py
@@ -40,10 +40,6 @@ async def run_app(
     # Router NOT started — no background thread
 
     state = {
-        "positions": {},
-        "known_hashes": {},
-        "next_id": 0,
-        "next_color": 0,
         "request_counter": 0,
     }
 

--- a/tests/test_dump_command.py
+++ b/tests/test_dump_command.py
@@ -218,8 +218,7 @@ async def test_dump_all_block_types():
             assert "SystemSection" in content
             assert "SYSTEM" in content
 
-            assert "TrackedContentBlock" in content
-            assert "Status:" in content
+            assert "TextContentBlock" in content
 
             assert "MessageBlock" in content
             assert "USER [" in content or "ASSISTANT [" in content
@@ -374,12 +373,7 @@ async def test_dump_handles_blocks_without_optional_fields():
                 detail=""
             ))
 
-            # TrackedContentBlock with old/new content
-            turn.blocks.append(fmt.TrackedContentBlock(
-                status="changed",
-                old_content="old",
-                new_content="new"
-            ))
+            turn.blocks.append(fmt.TextContentBlock(content="new"))
 
         # Should not crash
         with tempfile.NamedTemporaryFile(mode='w', suffix='.txt', delete=False) as f:

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,8 +1,9 @@
-"""Unit tests for formatting.py - block generation and content tracking."""
+"""Unit tests for formatting.py block generation."""
 
 import pytest
 
 from cc_dump.core.formatting import (
+    Category,
     ConfigContentBlock,
     ErrorBlock,
     FormattedBlock,
@@ -29,7 +30,6 @@ from cc_dump.core.formatting import (
     ToolDefsSection,
     ToolResultBlock,
     ToolUseBlock,
-    TrackedContentBlock,
     TurnBudgetBlock,
     UnknownTypeBlock,
     format_request,
@@ -39,8 +39,6 @@ from cc_dump.core.formatting import (
     format_openai_complete_response,
     format_response_event,
     format_response_headers,
-    make_diff_lines,
-    track_content,
     _tool_detail,
     _front_ellipse_path,
 )
@@ -103,9 +101,12 @@ def test_format_request_with_system(fresh_state):
     has_system_section = any(isinstance(b, SystemSection) for b in blocks)
     assert has_system_section
 
-    # Should have tracked content inside SystemSection
-    has_tracked = _has_block(blocks, TrackedContentBlock)
-    assert has_tracked
+    text_blocks = _find_blocks(blocks, TextContentBlock)
+    assert any(
+        block.content == "You are a helpful assistant."
+        and block.category == Category.SYSTEM
+        for block in text_blocks
+    )
 
 
 def test_format_request_with_system_list(fresh_state):
@@ -125,9 +126,9 @@ def test_format_request_with_system_list(fresh_state):
     has_system_section = any(isinstance(b, SystemSection) for b in blocks)
     assert has_system_section
 
-    # Should have tracked content blocks inside SystemSection
-    tracked_blocks = _find_blocks(blocks, TrackedContentBlock)
-    assert len(tracked_blocks) >= 2
+    text_blocks = _find_blocks(blocks, TextContentBlock)
+    system_texts = [block.content for block in text_blocks if block.category == Category.SYSTEM]
+    assert system_texts == ["Block 1", "Block 2"]
 
 
 def test_format_request_with_messages(fresh_state):
@@ -320,10 +321,7 @@ def test_format_request_long_first_message_keeps_text_content(fresh_state):
     blocks = format_request(body, fresh_state)
 
     text_blocks = _find_blocks(blocks, TextContentBlock)
-    tracked_blocks = _find_blocks(blocks, TrackedContentBlock)
-
     assert any(tb.content == long_text for tb in text_blocks)
-    assert tracked_blocks == []
 
 
 def test_format_request_with_tool_use(fresh_state):
@@ -627,141 +625,6 @@ def test_http_headers_block_defaults():
     assert block.status_code == 0
 
 
-# ─── track_content Tests ──────────────────────────────────────────────────────
-
-
-def test_track_content_new(fresh_state):
-    """First occurrence tagged 'new'."""
-    result = track_content("Hello world", "system:0", fresh_state)
-
-    assert isinstance(result, TrackedContentBlock)
-    assert result.status == "new"
-    assert result.tag_id.startswith("sp-")
-    assert isinstance(result.color_idx, int)
-    assert result.content == "Hello world"
-
-    # State should be updated
-    assert "system:0" in fresh_state["positions"]
-    assert fresh_state["next_id"] == 1
-
-
-def test_track_content_ref(fresh_state):
-    """Second occurrence of same content tagged 'ref'."""
-    # First call
-    track_content("Hello", "system:0", fresh_state)
-
-    # Second call with same content at different position
-    result = track_content("Hello", "msg:1", fresh_state)
-
-    assert isinstance(result, TrackedContentBlock)
-    assert result.status == "ref"
-    assert result.tag_id.startswith("sp-")
-    assert isinstance(result.color_idx, int)
-
-
-def test_track_content_changed(fresh_state):
-    """Modified content at same position tagged 'changed'."""
-    # First call
-    track_content("Original", "system:0", fresh_state)
-
-    # Second call with different content at same position
-    result = track_content("Modified", "system:0", fresh_state)
-
-    assert isinstance(result, TrackedContentBlock)
-    assert result.status == "changed"
-    assert result.tag_id.startswith("sp-")
-    assert isinstance(result.color_idx, int)
-    assert result.old_content == "Original"
-    assert result.new_content == "Modified"
-
-
-def test_track_content_multiple_positions_same_content(fresh_state):
-    """Same content at multiple positions shares tag."""
-    result1 = track_content("Shared", "pos:1", fresh_state)
-    result2 = track_content("Shared", "pos:2", fresh_state)
-
-    # First is new
-    assert isinstance(result1, TrackedContentBlock)
-    assert result1.status == "new"
-    tag_id_1 = result1.tag_id
-
-    # Second is ref to same tag
-    assert isinstance(result2, TrackedContentBlock)
-    assert result2.status == "ref"
-    tag_id_2 = result2.tag_id
-
-    assert tag_id_1 == tag_id_2
-
-
-# ─── make_diff_lines Tests ────────────────────────────────────────────────────
-
-
-def test_make_diff_lines_no_change():
-    """Empty diff for identical content."""
-    old = "Hello\nWorld"
-    new = "Hello\nWorld"
-
-    diff_lines = make_diff_lines(old, new)
-
-    # No changes means no diff output (after filtering header lines)
-    assert len(diff_lines) == 0
-
-
-def test_make_diff_lines_with_changes():
-    """Proper diff output for changes."""
-    old = "Hello\nWorld\nFoo"
-    new = "Hello\nEarth\nFoo"
-
-    diff_lines = make_diff_lines(old, new)
-
-    # Should have changes
-    assert len(diff_lines) > 0
-
-    # Check for hunk marker, deletions, and additions
-    kinds = [kind for kind, _ in diff_lines]
-    assert "hunk" in kinds or "remove" in kinds or "add" in kinds
-
-
-def test_make_diff_lines_addition():
-    """Addition detected in diff."""
-    old = "Line 1"
-    new = "Line 1\nLine 2"
-
-    diff_lines = make_diff_lines(old, new)
-
-    # Should have addition
-    kinds = [kind for kind, _ in diff_lines]
-    assert "add" in kinds
-
-
-def test_make_diff_lines_deletion():
-    """Deletion detected in diff."""
-    old = "Line 1\nLine 2"
-    new = "Line 1"
-
-    diff_lines = make_diff_lines(old, new)
-
-    # Should have deletion
-    kinds = [kind for kind, _ in diff_lines]
-    assert "remove" in kinds
-
-
-def test_make_diff_lines_format():
-    """Diff lines are (kind, text) tuples."""
-    old = "A"
-    new = "B"
-
-    diff_lines = make_diff_lines(old, new)
-
-    # Each line should be a tuple
-    for item in diff_lines:
-        assert isinstance(item, tuple)
-        assert len(item) == 2
-        kind, text = item
-        assert kind in ("hunk", "add", "remove")
-        assert isinstance(text, str)
-
-
 # ─── Block Instantiation Tests ────────────────────────────────────────────────
 
 
@@ -787,25 +650,7 @@ def test_block_types_can_be_instantiated():
     assert isinstance(ErrorBlock(code=500), FormattedBlock)
     assert isinstance(ProxyErrorBlock(error="error"), FormattedBlock)
     assert isinstance(NewlineBlock(), FormattedBlock)
-    assert isinstance(TrackedContentBlock(status="new"), FormattedBlock)
     assert isinstance(TurnBudgetBlock(), FormattedBlock)
-
-
-def test_tracked_content_block_fields():
-    """TrackedContentBlock has expected fields."""
-    block = TrackedContentBlock(
-        status="new",
-        tag_id="sp-1",
-        color_idx=0,
-        content="test",
-        indent="  ",
-    )
-
-    assert block.status == "new"
-    assert block.tag_id == "sp-1"
-    assert block.color_idx == 0
-    assert block.content == "test"
-    assert block.indent == "  "
 
 
 # ─── Integration Tests ────────────────────────────────────────────────────────
@@ -823,20 +668,6 @@ def test_format_request_multiple_calls_increment_counter(fresh_state):
 
     format_request(body, fresh_state)
     assert fresh_state["request_counter"] == 3
-
-
-def test_content_tracking_preserves_color_across_refs(fresh_state):
-    """Content tracking preserves color index across references."""
-    # Track content first time
-    result1 = track_content("Shared content", "pos:1", fresh_state)
-    color1 = result1.color_idx
-
-    # Track same content at different position
-    result2 = track_content("Shared content", "pos:2", fresh_state)
-    color2 = result2.color_idx
-
-    # Should have same color
-    assert color1 == color2
 
 
 # ─── Tool Detail Tests ────────────────────────────────────────────────────────
@@ -1498,10 +1329,6 @@ class TestToolUseBlockDescription:
 def _fresh_openai_state():
     return {
         "request_counter": 0,
-        "positions": {},
-        "known_hashes": {},
-        "next_id": 1,
-        "next_color": 0,
     }
 
 
@@ -1571,8 +1398,12 @@ class TestFormatOpenAIRequest:
 
         system_sections = _find_blocks(blocks, SystemSection)
         assert len(system_sections) == 1
-        # System section should have tracked content
-        assert len(system_sections[0].children) > 0
+        # System section should have plain system text content
+        assert len(system_sections[0].children) == 1
+        child = system_sections[0].children[0]
+        assert isinstance(child, TextContentBlock)
+        assert child.content == "You are a helpful assistant."
+        assert child.category == Category.SYSTEM
 
         # System message should NOT appear as a conversation MessageBlock
         msg_blocks = _find_blocks(blocks, MessageBlock)

--- a/tests/test_render_block_transforms.py
+++ b/tests/test_render_block_transforms.py
@@ -6,7 +6,6 @@ from cc_dump.core.formatting import (
     Category,
     NewlineBlock,
     TextContentBlock,
-    TrackedContentBlock,
     VisState,
 )
 from cc_dump.tui.rendering import render_turn_to_strips
@@ -16,10 +15,7 @@ def test_render_turn_to_strips_hides_empty_leaf_block_output():
     """Empty leaf output is filtered out of strips/flat block mapping."""
     console = Console()
     filters = {"system": VisState(True, False, True)}
-    block = TrackedContentBlock(
-        status="unknown-status",
-        category=Category.SYSTEM,
-    )
+    block = TextContentBlock(content="", category=Category.SYSTEM)
 
     strips, block_map, flat_blocks = render_turn_to_strips(
         [block],

--- a/tests/test_render_state_matrix.py
+++ b/tests/test_render_state_matrix.py
@@ -37,7 +37,6 @@ from cc_dump.core.formatting import (
     ToolResultBlock,
     ToolUseSummaryBlock,
     ToolUseBlock,
-    TrackedContentBlock,
     UnknownTypeBlock,
     ProxyErrorBlock,
     AgentDefChild,
@@ -99,7 +98,6 @@ def test_content_block_renderer_registry_has_four_distinct_visible_states():
         "ToolDefBlock",
         "SkillDefChild",
         "AgentDefChild",
-        "TrackedContentBlock",
         "ThinkingBlock",
         "ConfigContentBlock",
         "HookOutputBlock",
@@ -178,13 +176,10 @@ def test_core_content_blocks_respect_state_line_budgets():
             "tools",
         ),
         (
-            "TrackedContentBlock",
-            TrackedContentBlock(
-                status="changed",
-                tag_id="sp-1",
+            "TextContentBlock(system)",
+            TextContentBlock(
                 content="\n".join(f"tracked {i}" for i in range(1, 60)),
-                old_content="\n".join(f"old {i}" for i in range(1, 60)),
-                new_content="\n".join(f"new {i}" for i in range(1, 60)),
+                category=Category.SYSTEM,
             ),
             "system",
         ),
@@ -400,15 +395,9 @@ def test_container_blocks_keep_summary_views_bounded():
     )
     system_section = SystemSection(
         children=[
-            TrackedContentBlock(status="new", tag_id="sp-1", content="\n".join(f"n{i}" for i in range(40))),
-            TrackedContentBlock(
-                status="changed",
-                tag_id="sp-2",
-                content="\n".join(f"c{i}" for i in range(40)),
-                old_content="\n".join(f"old{i}" for i in range(40)),
-                new_content="\n".join(f"new{i}" for i in range(40)),
-            ),
-            TrackedContentBlock(status="ref", tag_id="sp-3", content="same"),
+            TextContentBlock(content="\n".join(f"n{i}" for i in range(40)), category=Category.SYSTEM),
+            TextContentBlock(content="\n".join(f"c{i}" for i in range(40)), category=Category.SYSTEM),
+            TextContentBlock(content="same", category=Category.SYSTEM),
         ]
     )
     tool_defs_section = ToolDefsSection(
@@ -551,10 +540,9 @@ def test_container_full_collapsed_hides_child_content():
 
     system_section = SystemSection(
         children=[
-            TrackedContentBlock(
-                status="new",
-                tag_id="sp-9",
+            TextContentBlock(
                 content=f"intro\n{unique_text}\noutro",
+                category=Category.SYSTEM,
             )
         ]
     )
@@ -839,15 +827,15 @@ def test_section_headers_summary_expanded_are_enriched():
 
     system_section = SystemSection(
         children=[
-            TrackedContentBlock(status="new", content="a"),
-            TrackedContentBlock(status="changed", content="b"),
-            TrackedContentBlock(status="ref", content="c"),
+            TextContentBlock(content="a", category=Category.SYSTEM),
+            TextContentBlock(content="b", category=Category.SYSTEM),
+            TextContentBlock(content="c", category=Category.SYSTEM),
         ]
     )
     sys_sc_text, _ = _render_plain(system_section, "system", SUMMARY_COLLAPSED)
     sys_se_text, _ = _render_plain(system_section, "system", SUMMARY_EXPANDED)
     assert "SYSTEM" in sys_sc_text
-    assert "status new:1 changed:1 ref:1" in sys_se_text
+    assert "(3 blocks)" in sys_se_text
 
     tool_defs = ToolDefsSection(tool_count=5, total_tokens=4200, children=[])
     td_sc_text, _ = _render_plain(tool_defs, "tools", SUMMARY_COLLAPSED)
@@ -982,8 +970,8 @@ def test_section_full_collapsed_and_expanded_renderers_are_distinct():
 
     system_section = SystemSection(
         children=[
-            TrackedContentBlock(status="new", content="a"),
-            TrackedContentBlock(status="changed", content="b"),
+            TextContentBlock(content="a", category=Category.SYSTEM),
+            TextContentBlock(content="b", category=Category.SYSTEM),
         ]
     )
     sys_fc = RENDERERS[("SystemSection", True, True, False)](system_section)
@@ -993,7 +981,7 @@ def test_section_full_collapsed_and_expanded_renderers_are_distinct():
     sys_fc_plain = _renderable_plain(sys_fc)
     sys_fe_plain = _renderable_plain(sys_fe)
     assert "(2 blocks)" in sys_fc_plain
-    assert "status" in sys_fe_plain
+    assert "TextContent" in sys_fe_plain
     assert sys_fc_plain != sys_fe_plain
 
     tool_defs = ToolDefsSection(
@@ -1052,15 +1040,17 @@ def test_section_summary_expanded_and_full_expanded_are_distinct():
 
     system_section = SystemSection(
         children=[
-            TrackedContentBlock(status="new", tag_id="sp-1", content="a"),
-            TrackedContentBlock(status="changed", tag_id="sp-2", content="b"),
-            TrackedContentBlock(status="ref", tag_id="sp-3", content="c"),
+            TextContentBlock(content="a", category=Category.SYSTEM),
+            TextContentBlock(content="b", category=Category.SYSTEM),
+            TextContentBlock(content="c", category=Category.SYSTEM),
         ]
     )
     sys_se, _ = _render_plain(system_section, "system", SUMMARY_EXPANDED)
     sys_fe, _ = _render_plain(system_section, "system", FULL_EXPANDED)
-    assert "status new:1 changed:1 ref:1" in sys_se
-    assert "tags sp-1, sp-2, sp-3" in sys_fe
+    assert "(3 blocks)" in sys_se
+    assert "a" in sys_fe
+    assert "b" in sys_fe
+    assert "c" in sys_fe
     assert sys_se != sys_fe
 
     response_metadata = ResponseMetadataSection(
@@ -1205,29 +1195,6 @@ def test_thinking_summary_expanded_shows_preview():
     assert se_text != sc_text
     assert fc_text != fe_text
     assert se_text != fe_text
-
-
-def test_tracked_content_full_collapsed_uses_bounded_snippet():
-    content = "\n".join(f"tracked line {i}" for i in range(1, 12))
-    block = TrackedContentBlock(
-        status="changed",
-        tag_id="sp-42",
-        content=content,
-        old_content="old 1\nold 2",
-        new_content=content,
-    )
-
-    sc_text, _ = _render_plain(block, "system", SUMMARY_COLLAPSED)
-    fc_text, _ = _render_plain(block, "system", FULL_COLLAPSED)
-    fe_text, _ = _render_plain(block, "system", FULL_EXPANDED)
-
-    assert "CHANGED" in sc_text
-    assert "tracked line 1" not in sc_text
-    assert "tracked line 1" in fc_text
-    assert "[snippet]" in fc_text
-    assert "tracked line 6" not in fc_text
-    assert "tracked line 6" in fe_text
-    assert fc_text != fe_text
 
 
 def test_text_delta_state_matrix_is_distinct():

--- a/tests/test_search.py
+++ b/tests/test_search.py
@@ -20,7 +20,6 @@ from cc_dump.core.formatting import (
     HttpHeadersBlock,
     MetadataBlock,
     SystemSection,
-    TrackedContentBlock,
     TextContentBlock,
     ToolUseBlock,
     ToolResultBlock,
@@ -69,21 +68,6 @@ SEARCHABLE_TEXT_CASES = [
         SystemSection(children=[]),
         ["SYSTEM"],
         id="system_section",
-    ),
-    pytest.param(
-        TrackedContentBlock(status="new", content="hello world"),
-        ["hello world"],
-        id="tracked_content_new",
-    ),
-    pytest.param(
-        TrackedContentBlock(status="changed", new_content="new stuff", old_content="old"),
-        ["new stuff"],
-        id="tracked_content_changed",
-    ),
-    pytest.param(
-        TrackedContentBlock(status="ref"),
-        [],
-        id="tracked_content_ref",
     ),
     pytest.param(
         MessageBlock(role="assistant", msg_index=3, children=[]),

--- a/tests/test_widget_arch.py
+++ b/tests/test_widget_arch.py
@@ -21,7 +21,6 @@ from cc_dump.core.formatting import (
     HeaderBlock,
     MetadataBlock,
     SystemSection,
-    TrackedContentBlock,
     TextContentBlock,
     ToolUseBlock,
     TextDeltaBlock,
@@ -71,7 +70,6 @@ class TestBlockCategoryCompleteness:
         assert BLOCK_CATEGORY["MetadataBlock"] == Category.METADATA
         assert BLOCK_CATEGORY["TurnBudgetBlock"] == Category.METADATA
         assert BLOCK_CATEGORY["SystemSection"] == Category.SYSTEM
-        assert BLOCK_CATEGORY["TrackedContentBlock"] == Category.SYSTEM
         assert BLOCK_CATEGORY["ToolUseBlock"] == Category.TOOLS
         assert BLOCK_CATEGORY["ToolResultBlock"] == Category.TOOLS
         assert BLOCK_CATEGORY["ToolUseSummaryBlock"] == Category.TOOLS
@@ -556,7 +554,7 @@ class TestScrollPreservation:
             [TextContentBlock(content="Turn 0", indent="")],
             [
                 SystemSection(children=[]),
-                TrackedContentBlock(status="new", tag_id="sys", color_idx=0, content="System"),
+                TextContentBlock(content="System", category=Category.SYSTEM),
             ],
             [
                 TextContentBlock(content="Turn 2 text\nLine 2", indent=""),
@@ -675,7 +673,7 @@ class TestScrollPreservation:
         turns_blocks = [
             [TextContentBlock(content="Turn 0 visible", indent="")],
             [SystemSection(children=[]),
-             TrackedContentBlock(status="new", tag_id="sys", color_idx=0, content="System only")],
+             TextContentBlock(content="System only", category=Category.SYSTEM)],
             [TextContentBlock(content="Turn 2 visible", indent="")],
         ]
         filters = {"system": ALWAYS_VISIBLE}


### PR DESCRIPTION
## Summary
Remove the system prompt tracking/diff feature. System prompt content now renders as ordinary system text instead of carrying cross-request tracking state, tags, or diff previews.

## Behavior Changes
### `src/cc_dump/core`
- Remove `TrackedContentBlock`, `track_content`, and `make_diff_lines` from the formatting layer.
- Format system prompts as plain `TextContentBlock` instances with `Category.SYSTEM`.
- Drop the obsolete formatting state keys used only for system prompt tracking.

### `src/cc_dump/tui`
- Remove tracked-content rendering branches from the Rich renderer.
- Simplify system section summary/full render behavior to reflect plain text children.
- Remove tracked-content handling from search text extraction and dump formatting.

### `tests/`
- Replace tracked-content assertions with plain system-text assertions.
- Remove obsolete tracked-content/diff-specific tests.
- Simplify shared test fixtures to the smaller formatting state shape.

## Removed Features
- System prompt tag IDs / "new" / "ref" / "changed" statuses.
- System prompt diff previews between requests.
- Cross-request mutable state for system prompt content tracking.

## Non-product files
- None.

## Validation
- `uv run pytest tests/test_formatting.py tests/test_render_state_matrix.py tests/test_widget_arch.py tests/test_dump_command.py tests/test_search.py tests/test_render_block_transforms.py tests/test_replay_pipeline.py tests/test_cli_run.py -q`
- `uv run mypy src/cc_dump/core/formatting_impl.py src/cc_dump/tui/rendering_impl.py src/cc_dump/tui/search.py src/cc_dump/tui/dump_formatting.py src/cc_dump/cli.py`
- `uv run ruff check src/cc_dump/core/formatting_impl.py src/cc_dump/tui/rendering_impl.py src/cc_dump/tui/search.py src/cc_dump/tui/dump_formatting.py src/cc_dump/cli.py tests/test_formatting.py tests/test_render_state_matrix.py tests/test_widget_arch.py tests/test_dump_command.py tests/test_search.py tests/test_render_block_transforms.py tests/conftest.py tests/harness/app_runner.py`
