### PR TITLE
Follow up PR #85 review concerns

### DIFF
--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -17,13 +17,14 @@ import time
 import tracemalloc
 import traceback
 from functools import lru_cache
-from typing import Callable, Optional, TypedDict, cast
+from typing import Callable, Optional, Protocol, TypedDict, cast
 
 import textual
 import textual.filter as _textual_filter
 from textual.app import App, ComposeResult, SystemCommand
 from textual.css.query import NoMatches
 from textual.message import Message
+from textual.widget import Widget
 from textual.widgets import Header, TabbedContent, TabPane
 from rich.style import Style
 
@@ -77,10 +78,27 @@ from snarfx import textual as stx
 logger = logging.getLogger(__name__)
 
 
-def _focused_widget_owns_key(widget: object | None, event) -> bool:
-    # [LAW:single-enforcer] Focused widgets are the sole authority on which keys they consume.
+class _KeyConsumer(Protocol):
+    def check_consume_key(self, key: str, character: str | None) -> bool:
+        ...
+
+
+class _NullKeyConsumer:
+    def check_consume_key(self, key: str, character: str | None) -> bool:
+        return False
+
+
+_NULL_KEY_CONSUMER = _NullKeyConsumer()
+
+
+def _resolve_key_consumer(widget: Widget | None) -> _KeyConsumer:
+    # [LAW:single-enforcer] Widgets are the sole authority for key consumption.
     check_consume_key = getattr(widget, "check_consume_key", None)
-    return bool(check_consume_key and check_consume_key(event.key, event.character))
+    return cast(_KeyConsumer, widget) if callable(check_consume_key) else _NULL_KEY_CONSUMER
+
+
+def _event_key_is_consumed(event, consumer: _KeyConsumer) -> bool:
+    return bool(consumer.check_consume_key(event.key, event.character))
 
 
 def _patch_textual_monochrome_style() -> None:
@@ -1543,7 +1561,7 @@ class CcDumpApp(App):
         if event.key == "escape" and self._close_topmost_panel():
             event.prevent_default()
             return True
-        if _focused_widget_owns_key(self.screen.focused, event):
+        if _event_key_is_consumed(event, _resolve_key_consumer(self.screen.focused)):
             return True
         if mode == InputMode.NORMAL and event.character == "/":
             event.prevent_default()

--- a/src/cc_dump/tui/launch_config_panel.py
+++ b/src/cc_dump/tui/launch_config_panel.py
@@ -259,11 +259,20 @@ def _make_base_widget(field: BaseFieldDef, value: object) -> Input | Select[str]
 
 
 def _select_values(selector: Select[str]) -> tuple[str, ...]:
-    return tuple(
-        str(value)
-        for _prompt, value in getattr(selector, "_options", [])
-        if value is not selector.BLANK
-    )
+    options = getattr(selector, "options", None)
+    if options is None:
+        return ()
+
+    values: list[str] = []
+    for option in options:
+        if isinstance(option, tuple) and len(option) >= 2:
+            _, value = option[:2]
+        else:
+            value = getattr(option, "value", option)
+        if value is selector.BLANK:
+            continue
+        values.append(str(value))
+    return tuple(values)
 
 
 def _base_field_display_value(field: BaseFieldDef, config) -> str:
@@ -278,6 +287,11 @@ def _base_field_display_value(field: BaseFieldDef, config) -> str:
     if field.key == "shell":
         return _shell_to_display(config.shell)
     return str(getattr(config, field.key, "") or "")
+
+
+def _selected_index_for_active_name(configs: Sequence, active_name: str) -> int:
+    names = [config.name for config in configs]
+    return names.index(active_name) if active_name in names else 0
 
 
 def _action_chip(
@@ -447,7 +461,7 @@ class LaunchConfigPanel(VerticalScroll):
         incoming = copy.deepcopy(configs)
         self._configs = incoming or cc_dump.app.launch_config.default_configs()
         self._active_name = active_config_name
-        self._selected_idx = 0
+        self._selected_idx = _selected_index_for_active_name(self._configs, self._active_name)
         self._view_revision = 0
         self._panel_state: Observable[LaunchConfigPanelViewState] = Observable(
             LaunchConfigPanelViewState(
@@ -526,10 +540,10 @@ class LaunchConfigPanel(VerticalScroll):
         )
 
     def on_mount(self) -> None:
-        if not self.display:
-            return
+        # [LAW:dataflow-not-control-flow] Always hydrate widget state on mount.
         self._apply_panel_state(self._panel_state.get())
-        self.focus_default_control()
+        if self.display:
+            self.focus_default_control()
 
     def on_unmount(self) -> None:
         self._panel_reaction.dispose()
@@ -669,13 +683,7 @@ class LaunchConfigPanel(VerticalScroll):
         incoming = copy.deepcopy(configs)
         self._configs = incoming or cc_dump.app.launch_config.default_configs()
         self._active_name = active_config_name
-        names = [config.name for config in self._configs]
-        target_name = ""
-        if self._active_name in names:
-            target_name = self._active_name
-        elif names:
-            target_name = names[0]
-        self._selected_idx = names.index(target_name) if target_name in names else 0
+        self._selected_idx = _selected_index_for_active_name(self._configs, self._active_name)
         self._emit_panel_state()
 
     def focus_default_control(self) -> None:

--- a/tests/harness/__init__.py
+++ b/tests/harness/__init__.py
@@ -10,6 +10,8 @@ from tests.harness.interactions import (
     press_sequence,
     click_and_settle,
     resize_and_settle,
+    settle,
+    choose_from_select,
 )
 from tests.harness.assertions import (
     get_vis_state,
@@ -39,6 +41,8 @@ __all__ = [
     "press_sequence",
     "click_and_settle",
     "resize_and_settle",
+    "settle",
+    "choose_from_select",
     "get_vis_state",
     "get_all_vis_states",
     "get_vis_level",

--- a/tests/harness/interactions.py
+++ b/tests/harness/interactions.py
@@ -5,6 +5,7 @@ waiting for CPU idle instead of fixed sleeps.
 """
 
 from textual.pilot import Pilot
+from textual.widgets import Select
 
 
 async def press_and_settle(pilot: Pilot, *keys: str) -> None:
@@ -32,3 +33,26 @@ async def resize_and_settle(pilot: Pilot, width: int, height: int) -> None:
     """Resize terminal and wait for app to settle."""
     await pilot.resize_terminal(width, height)
     await pilot.pause()
+
+
+async def settle(pilot: Pilot, ticks: int = 1) -> None:
+    """Pause one or more event-loop ticks."""
+    for _ in range(max(0, ticks)):
+        await pilot.pause()
+
+
+async def choose_from_select(
+    pilot: Pilot,
+    selector: Select[str],
+    *,
+    navigation_keys: list[str],
+    open_key: str = "enter",
+    confirm_key: str = "enter",
+) -> str:
+    """Focus a Select, open it, navigate options, and confirm."""
+    selector.focus()
+    await pilot.pause()
+    await press_and_settle(pilot, open_key)
+    await press_sequence(pilot, navigation_keys)
+    await press_and_settle(pilot, confirm_key)
+    return str(selector.value)

--- a/tests/test_textual_panels.py
+++ b/tests/test_textual_panels.py
@@ -5,11 +5,47 @@ import pytest
 from tests.harness import (
     run_app,
     press_and_settle,
+    choose_from_select,
+    settle,
     is_panel_visible,
     is_follow_mode,
 )
 
 pytestmark = pytest.mark.textual
+
+
+async def _open_launch_config_panel(app, pilot):
+    import cc_dump.tui.launch_config_panel
+
+    app.action_toggle_launch_config()
+    await pilot.pause()
+    return app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+
+
+def _first_other_value(values: list[str] | tuple[str, ...], current: str) -> str:
+    for value in values:
+        if value != current:
+            return value
+    return current
+
+
+async def _choose_selector_value(pilot, selector, target: str, option_order: list[str]) -> str:
+    values = [str(value) for value in option_order]
+    current = str(selector.value)
+    if target == current or target not in values or current not in values:
+        return current
+
+    current_idx = values.index(current)
+    target_idx = values.index(target)
+    direction = "down" if target_idx > current_idx else "up"
+    steps = abs(target_idx - current_idx)
+    open_key = "down" if direction == "up" else "enter"
+    return await choose_from_select(
+        pilot,
+        selector,
+        navigation_keys=[direction] * steps,
+        open_key=open_key,
+    )
 
 
 async def test_panel_cycling_dot():
@@ -144,98 +180,83 @@ async def test_command_palette_includes_launch_presets():
             assert f"Launch preset: {key}" in titles
 
 
+def test_launch_config_select_values_reads_public_options_shape():
+    import cc_dump.tui.launch_config_panel
+
+    class _FakeOption:
+        def __init__(self, value) -> None:
+            self.value = value
+
+    class _FakeSelect:
+        BLANK = object()
+
+        def __init__(self) -> None:
+            self.options = [
+                ("alpha", "alpha"),
+                _FakeOption("beta"),
+                ("blank", self.BLANK),
+            ]
+
+    selector = _FakeSelect()
+    assert cc_dump.tui.launch_config_panel._select_values(selector) == ("alpha", "beta")
+
+
 async def test_launch_config_select_changes_value_with_standard_select_keys():
     """Launch config selection changes once via standard select keyboard controls."""
     from textual.widgets import Select
-    import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
-
-        panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+        panel = await _open_launch_config_panel(app, pilot)
         panel.create_new_config()
-        await pilot.pause()
+        await settle(pilot)
         selector = panel.query_one("#lc-config-selector", Select)
         original = str(selector.value)
+        option_order = [config.name for config in panel._configs]
+        target = _first_other_value(option_order, original)
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        assert selector.expanded is True
-
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "enter")
-
-        changed = str(selector.value)
+        changed = await _choose_selector_value(pilot, selector, target, option_order)
         assert changed != original
 
-        await pilot.pause()
-        await pilot.pause()
+        await settle(pilot, ticks=2)
         assert str(selector.value) == changed
 
 
-async def test_launch_config_preset_select_round_trips_after_layout_change():
-    """Preset select should switch away and back even when the selected preset changes tool layout."""
+async def test_launch_config_preset_select_stays_stable_after_layout_change():
+    """Preset select should switch and keep the new value after tool-layout changes."""
     from textual.widgets import Select
-    import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
-
-        panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+        panel = await _open_launch_config_panel(app, pilot)
         selector = panel.query_one("#lc-config-selector", Select)
         original = str(selector.value)
+        option_order = [config.name for config in panel._configs]
+        changed_target = _first_other_value(option_order, original)
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "enter")
-        changed = str(selector.value)
+        changed = await _choose_selector_value(pilot, selector, changed_target, option_order)
         assert changed != original
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "up")
-        await press_and_settle(pilot, "enter")
-        assert str(selector.value) == original
-
-        await pilot.pause()
-        await pilot.pause()
-        assert str(selector.value) == original
+        await settle(pilot, ticks=2)
+        assert str(selector.value) == changed
 
 
 async def test_launch_config_launcher_select_handles_standard_keys_without_panel_shortcuts():
     """Focused select should own enter and arrow keys instead of triggering panel actions."""
+    import cc_dump.app.launcher_registry
     from textual.widgets import Select
-    import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
-
-        panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+        panel = await _open_launch_config_panel(app, pilot)
         selector = panel.query_one("#lc-field-launcher", Select)
         original = str(selector.value)
         config_count = len(panel._configs)
+        option_order = list(cc_dump.app.launcher_registry.launcher_keys())
+        changed_target = _first_other_value(option_order, original)
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        assert selector.expanded is True
-
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "enter")
-
-        changed = str(selector.value)
+        changed = await _choose_selector_value(pilot, selector, changed_target, option_order)
         assert changed != original
         assert len(panel._configs) == config_count
 
-        await pilot.pause()
-        await pilot.pause()
+        await settle(pilot, ticks=2)
         assert str(selector.value) == changed
 
         await press_and_settle(pilot, "tab")
@@ -247,17 +268,13 @@ async def test_launch_config_launcher_select_handles_standard_keys_without_panel
 async def test_launch_config_select_allows_unclaimed_app_shortcuts():
     """Focused select should keep its own keys but allow unrelated app shortcuts through."""
     from textual.widgets import Select
-    import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
-
-        panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+        panel = await _open_launch_config_panel(app, pilot)
         selector = panel.query_one("#lc-field-launcher", Select)
         original = str(selector.value)
         selector.focus()
-        await pilot.pause()
+        await settle(pilot)
 
         before = app.active_panel
         await press_and_settle(pilot, ".")
@@ -267,55 +284,62 @@ async def test_launch_config_select_allows_unclaimed_app_shortcuts():
 
 async def test_launch_config_launcher_select_round_trips_and_reopens_stably():
     """Launcher select should switch away, switch back, and reopen without oscillating."""
+    import cc_dump.app.launcher_registry
     from textual.widgets import Select
     import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
-
-        panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
+        panel = await _open_launch_config_panel(app, pilot)
         selector = panel.query_one("#lc-field-launcher", Select)
         original = str(selector.value)
+        option_order = list(cc_dump.app.launcher_registry.launcher_keys())
+        changed_target = _first_other_value(option_order, original)
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "enter")
-        changed = str(selector.value)
+        changed = await _choose_selector_value(pilot, selector, changed_target, option_order)
         assert changed != original
 
-        selector.focus()
-        await pilot.pause()
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "down")
-        await press_and_settle(pilot, "enter")
-        assert str(selector.value) == original
+        round_trip = await _choose_selector_value(pilot, selector, original, option_order)
+        assert round_trip == original
 
-        await pilot.pause()
-        await pilot.pause()
+        await settle(pilot, ticks=2)
         assert str(selector.value) == original
 
         app.action_toggle_launch_config()
-        await pilot.pause()
+        await settle(pilot)
         app.action_toggle_launch_config()
-        await pilot.pause()
+        await settle(pilot)
 
         reopened_panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
         reopened_selector = reopened_panel.query_one("#lc-field-launcher", Select)
         assert str(reopened_selector.value) == original
 
-        await pilot.pause()
-        await pilot.pause()
+        await settle(pilot, ticks=2)
         assert str(reopened_selector.value) == original
+
+
+async def test_launch_config_hidden_mount_hydrates_from_store(monkeypatch):
+    """Fresh hidden mount should hydrate selector/form state before first show."""
+    from textual.widgets import Select
+    import cc_dump.app.launch_config
+
+    configs = cc_dump.app.launch_config.default_configs()
+    if len(configs) < 2:
+        pytest.skip("requires at least two launch presets")
+    active_name = configs[1].name
+
+    monkeypatch.setattr(cc_dump.app.launch_config, "load_configs", lambda: configs)
+    monkeypatch.setattr(cc_dump.app.launch_config, "load_active_name", lambda: active_name)
+
+    async with run_app() as (pilot, app):
+        panel = await _open_launch_config_panel(app, pilot)
+        selector = panel.query_one("#lc-config-selector", Select)
+        assert str(selector.value) == active_name
 
 
 async def test_launch_config_save_chip_keeps_app_responsive():
     """Focused action chips should allow unrelated shortcuts and still handle activation keys."""
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
+        await _open_launch_config_panel(app, pilot)
 
         save_chip = app.screen.query_one("#lc-action-save")
         save_chip.focus()
@@ -333,8 +357,7 @@ async def test_launch_config_save_chip_keeps_app_responsive():
 async def test_launch_config_escape_closes_via_app_handler():
     """Escape should close launch config through the app-level panel dispatcher."""
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
+        await _open_launch_config_panel(app, pilot)
 
         await press_and_settle(pilot, "escape")
         assert not app._view_store.get("panel:launch_config")
@@ -345,8 +368,7 @@ async def test_launch_config_toggle_reopens_hidden_panel():
     import cc_dump.tui.launch_config_panel
 
     async with run_app() as (pilot, app):
-        app.action_toggle_launch_config()
-        await pilot.pause()
+        await _open_launch_config_panel(app, pilot)
         panel = app.screen.query_one(cc_dump.tui.launch_config_panel.LaunchConfigPanel)
         assert panel.display
 


### PR DESCRIPTION
## Summary

Follow-up to merged PR #85 that addresses the remaining review concerns and tightens test coverage around launch-config select behavior.

- `src/cc_dump/tui/app.py`
  - Replaced `_focused_widget_owns_key(widget: object | None, ...)` with a typed key-consumer contract (`_KeyConsumer`) and renamed dispatch helper to `_event_key_is_consumed(...)`.
  - Removed the `object | None` helper signature from key handling logic while preserving behavior.
- `src/cc_dump/tui/launch_config_panel.py`
  - Removed direct dependency on private `Select._options` in `_select_values(...)`; now prefers public `options` when available and degrades safely.
  - Ensured mount-time hydration always runs by applying panel state even when the panel is mounted hidden.
  - Unified selected-index derivation via `_selected_index_for_active_name(...)` so constructor + reset paths follow the same source-of-truth.
- `tests/harness`
  - Added reusable generic helpers (`settle`, `choose_from_select`) and re-exported them.
- `tests/test_textual_panels.py`
  - Refactored launch-config panel tests to use shared helpers (removes duplicated setup/interaction code).
  - Added regression coverage for:
    - public-options parsing path in `_select_values(...)`
    - hidden-mount launch panel hydration behavior

## Concern Mapping (PR #85)

1. `app.py` review note (widget typed as `object`, helper naming): **addressed**
2. `launch_config_panel.py` private `Select._options` usage: **addressed**
3. `launch_config_panel.py` `on_mount` hidden-panel hydration gap: **addressed**
4. `tests/test_textual_panels.py` duplicated setup/interaction code: **addressed**
5. `cycle_selector.py` click/render expansion race notes: **N/A in follow-up** (cycle-selector module was removed in #85)
6. `debug_settings_panel.py` “chip actions write store, reactions consume store”: **already satisfied in current master** (chip callbacks write `_toggle_state`; `_toggle_reaction` applies side effects)

## Validation

- `uv run pytest tests/test_textual_panels.py -q`
- `uv run pytest tests/test_textual_panels.py -k 'chip or launch_config' -q`
- `uv run pytest tests/test_debug_settings_panel.py tests/test_chip.py -q`
- `uv run mypy src/cc_dump/tui/app.py src/cc_dump/tui/launch_config_panel.py src/cc_dump/tui/debug_settings_panel.py`
- `uv run python scripts/quality_gate.py check`
