### PR TITLE
refactor: remove tmux zoom and auto-zoom integration

### DIFF
--- a/src/cc_dump/app/settings_store.py
+++ b/src/cc_dump/app/settings_store.py
@@ -16,7 +16,6 @@ logger = logging.getLogger(__name__)
 
 # [LAW:one-source-of-truth] All known settings and their defaults
 SCHEMA: dict[str, object] = {
-    "auto_zoom_default": False,
     "side_channel_enabled": True,
     "side_channel_global_kill": False,
     "side_channel_max_concurrent": 1,
@@ -93,17 +92,6 @@ def setup_reactions(store, context=None):
                 ("side_channel_budget_caps", coerce_str_object_dict, mgr.set_budget_caps),
             )
             for key, project, apply in manager_bindings:
-                disposers.append(_bind_setting(store, key, project, apply))
-
-        tmux = context.get("tmux_controller")
-        if tmux is not None:
-            tmux_bindings: tuple[
-                tuple[str, Callable[[object], object], Callable[[object], None]],
-                ...,
-            ] = (
-                ("auto_zoom_default", bool, lambda value: setattr(tmux, "auto_zoom", bool(value))),
-            )
-            for key, project, apply in tmux_bindings:
                 disposers.append(_bind_setting(store, key, project, apply))
 
     return disposers

--- a/src/cc_dump/app/tmux_controller.py
+++ b/src/cc_dump/app/tmux_controller.py
@@ -1,10 +1,9 @@
-"""Tmux integration for cc-dump — split panes, launch external tools, auto-zoom.
+"""Tmux integration for cc-dump — split panes, launch external tools, log tail.
 
 This module is STABLE — holds live pane references, never hot-reloaded.
 All libtmux usage is lazy-imported and wrapped in try/except.
 
 // [LAW:locality-or-seam] All tmux logic isolated here; rest of app uses is_available() + TmuxController.
-// [LAW:dataflow-not-control-flow] Zoom decisions via _ZOOM_DECISIONS lookup table.
 """
 
 from __future__ import annotations
@@ -21,12 +20,7 @@ if TYPE_CHECKING:
 
 from snarfx import Observable, watch
 
-from cc_dump.pipeline.event_types import (
-    PipelineEvent,
-    PipelineEventKind,
-    ResponseCompleteEvent,
-    StopReason,
-)
+from cc_dump.pipeline.event_types import PipelineEvent
 
 logger = logging.getLogger(__name__)
 
@@ -106,39 +100,6 @@ class LogTailResult:
         return "LogTailResult({})".format(parts)
 
 
-# ─── Zoom decision table ─────────────────────────────────────────────────────
-# Key: (PipelineEventKind, StopReason | None)
-# Value: True = zoom, False = unzoom, None = no-op
-# // [LAW:dataflow-not-control-flow] Table lookup, not if/elif chains.
-
-_ZOOM_DECISIONS: dict[tuple[PipelineEventKind, StopReason | None], bool | None] = {
-    (PipelineEventKind.REQUEST, None): True,
-    (PipelineEventKind.RESPONSE_COMPLETE, StopReason.END_TURN): False,
-    (PipelineEventKind.RESPONSE_COMPLETE, StopReason.MAX_TOKENS): False,
-    (PipelineEventKind.RESPONSE_COMPLETE, StopReason.TOOL_USE): None,
-    (PipelineEventKind.ERROR, None): False,
-    (PipelineEventKind.PROXY_ERROR, None): False,
-}
-
-
-def _extract_decision_key(
-    event: PipelineEvent,
-) -> tuple[PipelineEventKind, StopReason | None]:
-    """Extract the lookup key from a pipeline event.
-
-    For ResponseCompleteEvent, extract stop_reason from body dict.
-    For all other events, stop_reason is None.
-    """
-    stop_reason: StopReason | None = None
-    if isinstance(event, ResponseCompleteEvent):
-        sr_str = event.body.get("stop_reason", "") or ""
-        try:
-            stop_reason = StopReason(sr_str)
-        except ValueError:
-            stop_reason = StopReason.NONE
-    return (event.kind, stop_reason)
-
-
 def is_available() -> bool:
     """Check if tmux integration is possible ($TMUX set + libtmux importable)."""
     if not os.environ.get("TMUX"):
@@ -152,9 +113,8 @@ def is_available() -> bool:
 
 
 class TmuxController:
-    """Manages tmux pane splitting, zoom, and tool-launch lifecycle.
+    """Manages tmux pane splitting and tool-launch lifecycle.
 
-    // [LAW:single-enforcer] on_event() is the sole zoom decision point.
     // [LAW:single-enforcer] _validate_tool_pane() is the sole pane liveness check.
     """
 
@@ -164,11 +124,8 @@ class TmuxController:
         process_names: tuple[str, ...] = (),
         launch_env: dict[str, str] | None = None,
         launcher_label: str = "tool",
-        auto_zoom: bool = False,
     ) -> None:
         self.state = TmuxState.NOT_IN_TMUX
-        self._auto_zoom = bool(auto_zoom)
-        self._is_zoomed = False
         self._port: int | None = None  # legacy fallback path
         self._launch_command = ""
         self._process_names: tuple[str, ...] = ()
@@ -179,8 +136,6 @@ class TmuxController:
         self._our_pane: libtmux.Pane | None = None
         self._tool_pane: libtmux.Pane | None = None
         self.pane_alive = Observable(False)  # reactive — True while launched pane is alive
-        self.auto_zoom_state = Observable(self._auto_zoom)
-        self.zoomed_state = Observable(self._is_zoomed)
         self.configure_launcher(
             command=launch_command,
             process_names=process_names,
@@ -295,8 +250,6 @@ class TmuxController:
         except Exception:
             self._tool_pane = None
             self.state = TmuxState.READY
-            self._is_zoomed = False
-            self.zoomed_state.set(self._is_zoomed)
             return False
 
     def _find_tool_pane(self) -> "libtmux.Pane | None":
@@ -329,15 +282,6 @@ class TmuxController:
     def launch_command(self) -> str:
         """The base launcher command."""
         return self._launch_command
-
-    @property
-    def auto_zoom(self) -> bool:
-        return self._auto_zoom
-
-    @auto_zoom.setter
-    def auto_zoom(self, value: bool) -> None:
-        self._auto_zoom = bool(value)
-        self.auto_zoom_state.set(self._auto_zoom)
 
     def launch_tool(self, command: str = "") -> LaunchResult:
         """Evaluate preconditions, derive action, log, execute.
@@ -542,68 +486,15 @@ class TmuxController:
             _log("focus_tool error: {}".format(e))
             return False
 
-    def zoom(self) -> None:
-        """Zoom cc-dump pane to full screen. Idempotent."""
-        if self._is_zoomed or self._our_pane is None:
-            return
-        try:
-            self._our_pane.resize(zoom=True)
-            self._is_zoomed = True
-            self.zoomed_state.set(self._is_zoomed)
-        except Exception as e:
-            _log("zoom error: {}".format(e))
-
-    def unzoom(self) -> None:
-        """Unzoom cc-dump pane (restore split). Idempotent."""
-        if not self._is_zoomed or self._our_pane is None:
-            return
-        try:
-            self._our_pane.resize(zoom=True)
-            self._is_zoomed = False
-            self.zoomed_state.set(self._is_zoomed)
-        except Exception as e:
-            _log("unzoom error: {}".format(e))
-
-    def toggle_zoom(self) -> None:
-        """Manual zoom toggle."""
-        if self._is_zoomed:
-            self.unzoom()
-        else:
-            self.zoom()
-
-    def toggle_auto_zoom(self) -> None:
-        """Toggle automatic zoom on API activity."""
-        self.auto_zoom = not self.auto_zoom
-
     def on_event(self, event: PipelineEvent) -> None:
-        """Subscriber callback — table lookup determines zoom/unzoom.
+        """Subscriber callback for pipeline events.
 
-        // [LAW:dataflow-not-control-flow] Decision from _ZOOM_DECISIONS table.
-        Guards: only act when TOOL_RUNNING and auto_zoom is on.
+        Zoom behavior was intentionally removed; tmux zoom is user-driven.
         """
-        if self.state != TmuxState.TOOL_RUNNING or not self.auto_zoom:
-            return
-
-        # Validate pane is still alive before zoom logic
-        if not self._validate_tool_pane():
-            return
-
-        key = _extract_decision_key(event)
-        decision = _ZOOM_DECISIONS.get(key)
-
-        # // [LAW:dataflow-not-control-flow] decision is True/False/None
-        # None = no-op, True = zoom, False = unzoom
-        _ZOOM_ACTIONS = {
-            True: self.zoom,
-            False: self.unzoom,
-        }
-        action = _ZOOM_ACTIONS.get(decision)
-        if action is not None:
-            action()
+        _ = event
 
     def cleanup(self) -> None:
-        """Unzoom on shutdown. Does NOT kill the launched pane."""
-        self.unzoom()
+        """Shutdown hook. Does NOT kill the launched pane."""
 
 
 def _log(msg: str) -> None:

--- a/src/cc_dump/app/view_store.py
+++ b/src/cc_dump/app/view_store.py
@@ -39,8 +39,6 @@ SCHEMA["nav:follow"] = "active"
 # Footer inputs (previously app attributes or external reads)
 SCHEMA["filter:active"] = "1"               # str|None — default to F1 (Conversation)
 SCHEMA["tmux:available"] = False            # bool — mirrored from tmux controller
-SCHEMA["tmux:auto_zoom"] = False            # bool — mirrored from tmux controller
-SCHEMA["tmux:zoomed"] = False               # bool — mirrored from tmux controller
 SCHEMA["launch:active_name"] = ""           # str — was load_active_name() file I/O each call
 SCHEMA["launch:active_tool"] = "claude"     # str — active launcher key for footer chip label
 SCHEMA["theme:generation"] = 0              # int — bumped on theme change to invalidate footer
@@ -104,8 +102,6 @@ def create():
             "follow_state": store.get("nav:follow"),
             "active_filterset": store.get("filter:active"),
             "tmux_available": store.get("tmux:available"),
-            "tmux_auto_zoom": store.get("tmux:auto_zoom"),
-            "tmux_zoomed": store.get("tmux:zoomed"),
             "active_launch_config_name": store.get("launch:active_name"),
             "active_launch_tool": store.get("launch:active_tool"),
             "_gen": store.get("theme:generation"),

--- a/src/cc_dump/cli.py
+++ b/src/cc_dump/cli.py
@@ -592,18 +592,13 @@ def main():
             provider_endpoints=provider_endpoints,
         )
         active_launcher_label = active_profile.launcher_label.lower()
-        auto_zoom = bool(settings_store.get("auto_zoom_default"))
         tmux_ctrl = cc_dump.app.tmux_controller.TmuxController(
             launch_command=active_config.resolved_command,
             process_names=active_profile.process_names,
             launch_env=active_profile.environment,
             launcher_label=active_profile.launcher_label,
-            auto_zoom=auto_zoom,
         )
         tmux_ctrl.set_port(actual_port)
-        # Subscribe for both READY and TOOL_RUNNING (adoption case)
-        if tmux_ctrl.state in (TmuxState.READY, TmuxState.TOOL_RUNNING):
-            router.add_subscriber(DirectSubscriber(tmux_ctrl.on_event))
     # [LAW:dataflow-not-control-flow] Status message from state, not branching
     _TMUX_STATUS = {
         None: "disabled (not in tmux)" if not os.environ.get("TMUX") else "disabled (libtmux not installed)",

--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -878,22 +878,14 @@ class CcDumpApp(App):
             logger.log(level_num, message, extra={"cc_dump_in_app": True})
 
     def _tmux_store_projection(self, tmux) -> dict[str, bool]:
-        """Compute footer-facing tmux flags from controller state/observables."""
+        """Compute footer-facing tmux availability flag from controller state."""
         _TMUX_ACTIVE = {cc_dump.app.tmux_controller.TmuxState.READY, cc_dump.app.tmux_controller.TmuxState.TOOL_RUNNING}
         if tmux is None:
             return {
                 "tmux:available": False,
-                "tmux:auto_zoom": False,
-                "tmux:zoomed": False,
             }
-        auto_obs = getattr(tmux, "auto_zoom_state", None)
-        zoom_obs = getattr(tmux, "zoomed_state", None)
-        auto_zoom = auto_obs.get() if auto_obs is not None else bool(getattr(tmux, "auto_zoom", False))
-        zoomed = zoom_obs.get() if zoom_obs is not None else bool(getattr(tmux, "_is_zoomed", False))
         return {
             "tmux:available": tmux.state in _TMUX_ACTIVE,
-            "tmux:auto_zoom": auto_zoom,
-            "tmux:zoomed": zoomed,
         }
 
     def _sync_tmux_to_store(self):
@@ -1208,22 +1200,6 @@ class CcDumpApp(App):
     def action_launch_tool(self):
         config = cc_dump.app.launch_config.get_active_config()
         self._launch_with_config(config, log_label="launch_tool")
-
-    def action_toggle_tmux_zoom(self):
-        tmux = self._tmux_controller
-        if tmux is None:
-            self.notify("Tmux not available", severity="warning")
-            return
-        tmux.toggle_zoom()
-
-    def action_toggle_auto_zoom(self):
-        tmux = self._tmux_controller
-        if tmux is None:
-            self.notify("Tmux not available", severity="warning")
-            return
-        tmux.toggle_auto_zoom()
-        label = "on" if tmux.auto_zoom else "off"
-        self.notify("Auto-zoom: {}".format(label))
 
     def action_open_tmux_log_tail(self):
         tmux = self._tmux_controller

--- a/src/cc_dump/tui/custom_footer.py
+++ b/src/cc_dump/tui/custom_footer.py
@@ -56,7 +56,7 @@ class StatusFooter(StoreWidget):
         opacity: 0.7;
     }
 
-    /* Dim chips (follow off, zoom/auto off): same hover pattern */
+    /* Dim chips: same hover pattern */
     StatusFooter Chip.-dim {
         opacity: 0.5;
     }
@@ -141,18 +141,6 @@ class StatusFooter(StoreWidget):
                 id="cmd-launch-tool",
                 classes="tmux",
             )
-            yield Chip(
-                " z zoom ",
-                action="app.toggle_tmux_zoom",
-                id="cmd-zoom",
-                classes="tmux",
-            )
-            yield Chip(
-                " Z auto ",
-                action="app.toggle_auto_zoom",
-                id="cmd-auto-zoom",
-                classes="tmux",
-            )
         # Line 3: log row
         runtime = cc_dump.io.logging_setup.get_runtime()
         log_path = runtime.file_path if runtime is not None else ""
@@ -231,8 +219,6 @@ class StatusFooter(StoreWidget):
     def _apply_tmux_controls(self, state: dict[str, object]) -> None:
         # // [LAW:dataflow-not-control-flow] Always run; state values vary style.
         tmux_available = bool(state.get("tmux_available", False))
-        tmux_auto = bool(state.get("tmux_auto_zoom", False))
-        tmux_zoomed = bool(state.get("tmux_zoomed", False))
         for widget in self.query(".tmux"):
             widget.set_class(tmux_available, "-available")
 
@@ -246,13 +232,3 @@ class StatusFooter(StoreWidget):
             else ""
         )
         launch_chip.update(f" c {active_tool_label}{config_suffix} ")
-
-        zoom_chip = self.query_one("#cmd-zoom", Chip)
-        zoom_chip.update(" z zoom ")
-        zoom_chip.set_class(not tmux_zoomed, "-dim")
-        zoom_chip.styles.text_style = "bold reverse" if tmux_zoomed else None
-
-        auto_chip = self.query_one("#cmd-auto-zoom", Chip)
-        auto_chip.update(" Z auto ")
-        auto_chip.set_class(not tmux_auto, "-dim")
-        auto_chip.styles.text_style = "bold reverse" if tmux_auto else None

--- a/src/cc_dump/tui/input_modes.py
+++ b/src/cc_dump/tui/input_modes.py
@@ -90,8 +90,6 @@ MODE_KEYMAP: dict[InputMode, dict[str, str]] = {
 
         # Tmux integration
         "c": "launch_tool",
-        "z": "toggle_tmux_zoom",
-        "Z": "toggle_auto_zoom",
         "L": "open_tmux_log_tail",
 
         # Filterset cycling (printable — NORMAL only)
@@ -168,7 +166,6 @@ FOOTER_KEYS: dict[InputMode, list[tuple[str, str]]] = {
         ("?", "keys"),
         ("/", "search"),
         ("c", "launch"),
-        ("z", "zoom"),
         ("L", "tail"),
     ],
     InputMode.SEARCH_EDIT: [
@@ -226,7 +223,6 @@ KEY_GROUPS: list[tuple[str, list[tuple[str, str]]]] = [
         ("c", "Launch tool (tmux)"),
         ("C", "Run configs"),
         ("D", "Debug"),
-        ("z/Z", "Zoom (tmux)"),
         ("L", "Tail logs (tmux)"),
         ("S", "Settings"),
         ("D", "Debug"),

--- a/src/cc_dump/tui/lifecycle_controller.py
+++ b/src/cc_dump/tui/lifecycle_controller.py
@@ -96,13 +96,9 @@ def _wire_reactive_runtime(app) -> None:
     def _tmux_projection():
         tmux = app._tmux_controller
         if tmux is None:
-            return (False, False, False)
+            return False
         pane_alive = tmux.pane_alive.get() if hasattr(tmux, "pane_alive") else False
-        auto_obs = getattr(tmux, "auto_zoom_state", None)
-        zoom_obs = getattr(tmux, "zoomed_state", None)
-        auto_zoom = auto_obs.get() if auto_obs is not None else bool(getattr(tmux, "auto_zoom", False))
-        zoomed = zoom_obs.get() if zoom_obs is not None else bool(getattr(tmux, "_is_zoomed", False))
-        return (pane_alive, auto_zoom, zoomed)
+        return pane_alive
 
     stx.reaction(
         app,

--- a/src/cc_dump/tui/settings_panel.py
+++ b/src/cc_dump/tui/settings_panel.py
@@ -52,13 +52,6 @@ class SettingsPanelViewState:
 
 SETTINGS_FIELDS: list[FieldDef] = [
     FieldDef(
-        key="auto_zoom_default",
-        label="Auto-Zoom Default",
-        description="Start with tmux auto-zoom enabled",
-        kind="bool",
-        default=cc_dump.app.settings_store.SCHEMA["auto_zoom_default"],
-    ),
-    FieldDef(
         key="side_channel_enabled",
         label="AI Summaries",
         description="Enable AI-powered summaries via claude -p",

--- a/tests/test_d6u_smoke_checks.py
+++ b/tests/test_d6u_smoke_checks.py
@@ -176,19 +176,15 @@ def test_m3_replay_parity_matches_live_analytics_projection():
     assert replay_store.get_latest_turn_stats() == live_store.get_latest_turn_stats()
 
 
-def test_m4_tmux_auto_zoom_request_then_end_turn():
-    """M4: tmux auto-zoom zooms on request and unzooms on end_turn."""
+def test_m4_tmux_event_subscriber_is_noop():
+    """M4: tmux event callback is intentionally a no-op after zoom removal."""
     with patch.dict("os.environ", {}, clear=True):
         controller = TmuxController()
 
-    pane = MagicMock()
     controller.state = TmuxState.TOOL_RUNNING
-    controller.auto_zoom = True
-    controller._our_pane = pane
+    controller._our_pane = MagicMock()
     controller._tool_pane = MagicMock()
 
     controller.on_event(RequestBodyEvent(body={}))
-    assert controller._is_zoomed is True
-
     controller.on_event(ResponseCompleteEvent(body={"stop_reason": "end_turn"}))
-    assert controller._is_zoomed is False
+    assert controller.state == TmuxState.TOOL_RUNNING

--- a/tests/test_settings_io.py
+++ b/tests/test_settings_io.py
@@ -20,16 +20,16 @@ def tmp_settings(tmp_path, monkeypatch):
 
 def test_merge_setting_returns_new_dict():
     original = {"theme": "dark"}
-    merged = cc_dump.io.settings.merge_setting(original, "auto_zoom_default", True)
-    assert merged == {"theme": "dark", "auto_zoom_default": True}
+    merged = cc_dump.io.settings.merge_setting(original, "side_channel_enabled", False)
+    assert merged == {"theme": "dark", "side_channel_enabled": False}
     assert original == {"theme": "dark"}
     assert merged is not original
 
 
 def test_save_setting_merges_into_existing(tmp_settings):
     tmp_settings.write_text(json.dumps({"theme": "gruvbox"}))
-    cc_dump.io.settings.save_setting("auto_zoom_default", False)
+    cc_dump.io.settings.save_setting("side_channel_enabled", False)
 
     data = json.loads(tmp_settings.read_text())
     assert data["theme"] == "gruvbox"
-    assert data["auto_zoom_default"] is False
+    assert data["side_channel_enabled"] is False

--- a/tests/test_settings_store.py
+++ b/tests/test_settings_store.py
@@ -23,7 +23,6 @@ def tmp_settings(tmp_path, monkeypatch):
 class TestCreate:
     def test_creates_store_with_schema_defaults(self, tmp_settings):
         store = cc_dump.app.settings_store.create()
-        assert store.get("auto_zoom_default") is False
         assert store.get("side_channel_enabled") is True
         assert store.get("side_channel_global_kill") is False
         assert store.get("side_channel_max_concurrent") == 1
@@ -39,7 +38,7 @@ class TestCreate:
         store = cc_dump.app.settings_store.create()
         assert store.get("theme") == "gruvbox"
         # Unset keys get schema defaults
-        assert store.get("auto_zoom_default") is False
+        assert store.get("side_channel_enabled") is True
 
     def test_initial_overrides(self, tmp_settings):
         store = cc_dump.app.settings_store.create(initial_overrides={"theme": "dark"})
@@ -94,17 +93,6 @@ class TestSetupReactions:
 
         store.set("side_channel_max_concurrent", "not-a-number")
         mgr.set_max_concurrent.assert_called_with(1)
-
-    def test_tmux_auto_zoom_sync(self, tmp_settings):
-        store = cc_dump.app.settings_store.create()
-        tmux = MagicMock()
-        tmux.auto_zoom = False
-        context = {"tmux_controller": tmux}
-        disposers = cc_dump.app.settings_store.setup_reactions(store, context)
-        store._reaction_disposers = disposers
-
-        store.set("auto_zoom_default", True)
-        assert tmux.auto_zoom is True
 
     def test_no_context_still_persists(self, tmp_settings):
         store = cc_dump.app.settings_store.create()
@@ -165,8 +153,8 @@ class TestReactiveTracking:
     def test_update_batches(self, tmp_settings):
         store = cc_dump.app.settings_store.create()
         log = []
-        autorun(lambda: log.append((store.get("auto_zoom_default"), store.get("theme"))))
-        assert log == [(False, None)]
-        store.update({"auto_zoom_default": True, "theme": "y"})
+        autorun(lambda: log.append((store.get("side_channel_enabled"), store.get("theme"))))
+        assert log == [(True, None)]
+        store.update({"side_channel_enabled": False, "theme": "y"})
         # Single batch, not two separate updates
-        assert log == [(False, None), (True, "y")]
+        assert log == [(True, None), (False, "y")]

--- a/tests/test_tmux_controller.py
+++ b/tests/test_tmux_controller.py
@@ -1,4 +1,4 @@
-"""Tests for tmux_controller — zoom decisions, state machine, event handling.
+"""Tests for tmux_controller launch/adopt/log-tail behavior.
 
 All tests mock libtmux and tmux env vars; no actual tmux required.
 """
@@ -8,22 +8,12 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from cc_dump.pipeline.event_types import (
-    ErrorEvent,
-    PipelineEventKind,
-    ProxyErrorEvent,
-    RequestBodyEvent,
-    ResponseCompleteEvent,
-    ResponseDoneEvent,
-    StopReason,
-)
+from cc_dump.pipeline.event_types import RequestBodyEvent
 from cc_dump.app.tmux_controller import (
     LogTailAction,
     LaunchAction,
     TmuxController,
     TmuxState,
-    _ZOOM_DECISIONS,
-    _extract_decision_key,
     is_available,
 )
 
@@ -32,7 +22,7 @@ from cc_dump.app.tmux_controller import (
 
 
 _VALID_ATTRS = frozenset({
-    "state", "auto_zoom", "_is_zoomed", "_port",
+    "state", "_port",
     "_launch_command", "_process_names", "_launch_env", "_launcher_label",
     "_server", "_session", "_our_pane", "_tool_pane",
 })
@@ -56,81 +46,6 @@ def make_controller():
         return ctrl
 
     return _factory
-
-
-@pytest.fixture
-def active_controller(make_controller):
-    """Controller in TOOL_RUNNING state with mocked panes and auto_zoom on."""
-    return make_controller(
-        state=TmuxState.TOOL_RUNNING,
-        auto_zoom=True,
-        _our_pane=MagicMock(),
-        _tool_pane=MagicMock(),
-    )
-
-
-# ─── _ZOOM_DECISIONS table ───────────────────────────────────────────────────
-
-
-class TestZoomDecisions:
-    """Verify the zoom decision table entries."""
-
-    def test_request_zooms(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.REQUEST, None)] is True
-
-    def test_end_turn_unzooms(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.RESPONSE_COMPLETE, StopReason.END_TURN)] is False
-
-    def test_max_tokens_unzooms(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.RESPONSE_COMPLETE, StopReason.MAX_TOKENS)] is False
-
-    def test_tool_use_is_noop(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.RESPONSE_COMPLETE, StopReason.TOOL_USE)] is None
-
-    def test_error_unzooms(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.ERROR, None)] is False
-
-    def test_proxy_error_unzooms(self):
-        assert _ZOOM_DECISIONS[(PipelineEventKind.PROXY_ERROR, None)] is False
-
-
-# ─── _extract_decision_key ───────────────────────────────────────────────────
-
-
-class TestExtractDecisionKey:
-    def test_request_body_event(self):
-        event = RequestBodyEvent(body={})
-        assert _extract_decision_key(event) == (PipelineEventKind.REQUEST, None)
-
-    def test_response_complete_end_turn(self):
-        event = ResponseCompleteEvent(body={"stop_reason": "end_turn"})
-        assert _extract_decision_key(event) == (PipelineEventKind.RESPONSE_COMPLETE, StopReason.END_TURN)
-
-    def test_response_complete_tool_use(self):
-        event = ResponseCompleteEvent(body={"stop_reason": "tool_use"})
-        assert _extract_decision_key(event) == (PipelineEventKind.RESPONSE_COMPLETE, StopReason.TOOL_USE)
-
-    def test_response_complete_max_tokens(self):
-        event = ResponseCompleteEvent(body={"stop_reason": "max_tokens"})
-        assert _extract_decision_key(event) == (PipelineEventKind.RESPONSE_COMPLETE, StopReason.MAX_TOKENS)
-
-    def test_response_complete_no_stop_reason(self):
-        """ResponseCompleteEvent with no stop_reason gets StopReason.NONE."""
-        event = ResponseCompleteEvent(body={})
-        assert _extract_decision_key(event) == (PipelineEventKind.RESPONSE_COMPLETE, StopReason.NONE)
-
-    def test_response_complete_unknown_stop_reason(self):
-        """Unknown stop_reason falls back to StopReason.NONE."""
-        event = ResponseCompleteEvent(body={"stop_reason": "something_new"})
-        assert _extract_decision_key(event) == (PipelineEventKind.RESPONSE_COMPLETE, StopReason.NONE)
-
-    def test_error_event(self):
-        event = ErrorEvent(code=500, reason="server error")
-        assert _extract_decision_key(event) == (PipelineEventKind.ERROR, None)
-
-    def test_proxy_error_event(self):
-        event = ProxyErrorEvent(error="connection refused")
-        assert _extract_decision_key(event) == (PipelineEventKind.PROXY_ERROR, None)
 
 
 # ─── is_available() ──────────────────────────────────────────────────────────
@@ -167,155 +82,24 @@ class TestTmuxControllerStates:
         assert result.action == LaunchAction.BLOCKED
         assert not result.success
 
-    def test_not_in_tmux_zoom_is_noop(self, make_controller):
-        ctrl = make_controller()
-        ctrl.zoom()
-        assert ctrl._is_zoomed is False
-
-
-# ─── on_event behavior ──────────────────────────────────────────────────────
-
-
-class TestOnEvent:
-    def test_request_triggers_zoom(self, active_controller):
-        event = RequestBodyEvent(body={})
-        active_controller.on_event(event)
-        assert active_controller._is_zoomed is True
-        active_controller._our_pane.resize.assert_called_once_with(zoom=True)
-
-    def test_end_turn_triggers_unzoom(self, make_controller):
+class TestEventHooks:
+    def test_on_event_is_noop(self, make_controller):
         ctrl = make_controller(
             state=TmuxState.TOOL_RUNNING,
-            auto_zoom=True,
-            _is_zoomed=True,
             _our_pane=MagicMock(),
             _tool_pane=MagicMock(),
         )
-        event = ResponseCompleteEvent(body={"stop_reason": "end_turn"})
-        ctrl.on_event(event)
-        assert ctrl._is_zoomed is False
+        ctrl.on_event(RequestBodyEvent(body={}))
+        assert ctrl.state == TmuxState.TOOL_RUNNING
 
-    def test_tool_use_is_noop(self, make_controller):
+    def test_cleanup_is_noop(self, make_controller):
         ctrl = make_controller(
             state=TmuxState.TOOL_RUNNING,
-            auto_zoom=True,
-            _is_zoomed=True,
             _our_pane=MagicMock(),
             _tool_pane=MagicMock(),
-        )
-        event = ResponseCompleteEvent(body={"stop_reason": "tool_use"})
-        ctrl.on_event(event)
-        # Should stay zoomed — no change
-        assert ctrl._is_zoomed is True
-        ctrl._our_pane.resize.assert_not_called()
-
-    def test_error_triggers_unzoom(self, make_controller):
-        ctrl = make_controller(
-            state=TmuxState.TOOL_RUNNING,
-            auto_zoom=True,
-            _is_zoomed=True,
-            _our_pane=MagicMock(),
-            _tool_pane=MagicMock(),
-        )
-        event = ErrorEvent(code=500, reason="fail")
-        ctrl.on_event(event)
-        assert ctrl._is_zoomed is False
-
-    def test_proxy_error_triggers_unzoom(self, make_controller):
-        ctrl = make_controller(
-            state=TmuxState.TOOL_RUNNING,
-            auto_zoom=True,
-            _is_zoomed=True,
-            _our_pane=MagicMock(),
-            _tool_pane=MagicMock(),
-        )
-        event = ProxyErrorEvent(error="connection refused")
-        ctrl.on_event(event)
-        assert ctrl._is_zoomed is False
-
-    def test_auto_zoom_off_ignores_events(self, active_controller):
-        active_controller.auto_zoom = False
-        event = RequestBodyEvent(body={})
-        active_controller.on_event(event)
-        assert active_controller._is_zoomed is False
-        active_controller._our_pane.resize.assert_not_called()
-
-    def test_not_claude_running_ignores_events(self, make_controller):
-        ctrl = make_controller(
-            state=TmuxState.READY,
-            _our_pane=MagicMock(),
-            _tool_pane=MagicMock(),
-        )
-        event = RequestBodyEvent(body={})
-        ctrl.on_event(event)
-        assert ctrl._is_zoomed is False
-        ctrl._our_pane.resize.assert_not_called()
-
-    def test_response_done_no_decision(self, active_controller):
-        """ResponseDoneEvent has no table entry — no-op."""
-        event = ResponseDoneEvent()
-        active_controller.on_event(event)
-        assert active_controller._is_zoomed is False
-        active_controller._our_pane.resize.assert_not_called()
-
-
-# ─── Zoom idempotency ───────────────────────────────────────────────────────
-
-
-class TestZoomIdempotency:
-    def test_zoom_when_already_zoomed_is_noop(self, make_controller):
-        ctrl = make_controller(
-            _is_zoomed=True,
-            _our_pane=MagicMock(),
-        )
-        ctrl.zoom()
-        ctrl._our_pane.resize.assert_not_called()
-
-    def test_unzoom_when_not_zoomed_is_noop(self, make_controller):
-        ctrl = make_controller(_our_pane=MagicMock())
-        ctrl.unzoom()
-        ctrl._our_pane.resize.assert_not_called()
-
-    def test_toggle_zoom(self, make_controller):
-        ctrl = make_controller(_our_pane=MagicMock())
-        ctrl.toggle_zoom()
-        assert ctrl._is_zoomed is True
-        ctrl.toggle_zoom()
-        assert ctrl._is_zoomed is False
-
-
-# ─── toggle_auto_zoom ────────────────────────────────────────────────────────
-
-
-class TestToggleAutoZoom:
-    def test_toggle(self, make_controller):
-        ctrl = make_controller()
-        assert ctrl.auto_zoom is False
-        ctrl.toggle_auto_zoom()
-        assert ctrl.auto_zoom is True
-        ctrl.toggle_auto_zoom()
-        assert ctrl.auto_zoom is False
-
-
-# ─── cleanup ─────────────────────────────────────────────────────────────────
-
-
-class TestCleanup:
-    def test_cleanup_unzooms(self, make_controller):
-        ctrl = make_controller(
-            _is_zoomed=True,
-            _our_pane=MagicMock(),
         )
         ctrl.cleanup()
-        assert ctrl._is_zoomed is False
-        ctrl._our_pane.resize.assert_called_once_with(zoom=True)
-
-    def test_cleanup_when_not_zoomed_is_noop(self, make_controller):
-        ctrl = make_controller(
-            _our_pane=MagicMock(),
-        )
-        ctrl.cleanup()
-        ctrl._our_pane.resize.assert_not_called()
+        assert ctrl.state == TmuxState.TOOL_RUNNING
 
 # ─── _validate_tool_pane ─────────────────────────────────────────────────
 
@@ -809,18 +593,15 @@ class TestAutoResume:
 
 
 class TestOnEventWithDeadPane:
-    def test_dead_pane_skips_zoom(self, make_controller):
-        """on_event with dead tool pane should not attempt zoom."""
+    def test_dead_pane_is_untouched_by_noop_event_hook(self, make_controller):
         dead_pane = MagicMock()
         dead_pane.refresh.side_effect = Exception("pane dead")
         ctrl = make_controller(
             state=TmuxState.TOOL_RUNNING,
-            auto_zoom=True,
             _our_pane=MagicMock(),
             _tool_pane=dead_pane,
         )
-        event = RequestBodyEvent(body={})
-        ctrl.on_event(event)
-        # Pane was dead, so state transitioned to READY
-        assert ctrl.state == TmuxState.READY
-        assert ctrl._is_zoomed is False
+        ctrl.on_event(RequestBodyEvent(body={}))
+        # on_event no longer mutates pane state; pane validation remains launch/focus-owned.
+        assert ctrl.state == TmuxState.TOOL_RUNNING
+        assert ctrl._tool_pane is dead_pane

--- a/tests/test_view_store.py
+++ b/tests/test_view_store.py
@@ -296,8 +296,6 @@ class TestFooterStateComputed:
         state = store.footer_state.get()
         assert state["active_filterset"] == "1"
         assert state["tmux_available"] is False
-        assert state["tmux_auto_zoom"] is False
-        assert state["tmux_zoomed"] is False
         assert state["active_launch_config_name"] == ""
 
     def test_updates_on_store_change(self):


### PR DESCRIPTION
## Summary
### `src/cc_dump/app`
- Removed tmux zoom/auto-zoom behavior from `TmuxController` (state, methods, and event-driven zoom decisions).
- Removed `auto_zoom_default` from settings schema/reactions.
- Removed zoom-related tmux footer fields from view-store computed state.
- Dropped CLI wiring that subscribed pipeline events for tmux zoom decisions.

### `src/cc_dump/tui`
- Removed zoom/auto-zoom chips and rendering logic from the footer.
- Removed `z`/`Z` key bindings and help text for tmux zoom.
- Simplified lifecycle tmux projection to pane-liveness only (for store sync).

### `tests/`
- Rewrote tmux tests around retained behavior (launch/adopt/focus/log-tail + no-op event hook).
- Updated settings/view-store/smoke tests to remove zoom setting/state expectations.

## Removed Features
- Tmux zoom toggle action (`toggle_tmux_zoom`).
- Tmux auto-zoom toggle action (`toggle_auto_zoom`).
- Event-driven tmux zoom/unzoom on request/response lifecycle.
- `auto_zoom_default` user setting and related persistence/sync behavior.

## Non-product files
- None.

## Validation
- `uv run pytest tests/test_tmux_controller.py tests/test_settings_store.py tests/test_settings_io.py tests/test_view_store.py tests/test_input_modes.py tests/test_d6u_smoke_checks.py -q`
- `uv run pytest -q`
- `uv run mypy src`
- `uv run python scripts/quality_gate.py check`