### PR TITLE
refactor: remove --seed-hue CLI argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,6 @@ HAR files are the source of truth for events. Replay mode loads previous data, t
 | `--continue` | — | Continue from most recent recording (replay + live proxy) |
 | `--record PATH` | auto | Custom HAR recording output directory |
 | `--no-record` | — | Disable HAR recording |
-| `--seed-hue HUE` | `190` (cyan) | Base hue (0–360) for the color palette. Also settable via `CC_DUMP_SEED_HUE` env var |
 
 ## Features
 
@@ -318,7 +317,7 @@ Each press cycles: current → next visibility level.
 | Variable | Description |
 |----------|-------------|
 | `ANTHROPIC_BASE_URL` | Default upstream target (overridden by `--target`) |
-| `CC_DUMP_SEED_HUE` | Base hue (0–360) for the color palette (overridden by `--seed-hue`) |
+| `CC_DUMP_SEED_HUE` | Base hue (0–360) for the color palette |
 
 ## Development
 

--- a/src/cc_dump/cli.py
+++ b/src/cc_dump/cli.py
@@ -403,12 +403,6 @@ def main():
         help="Preview recording cleanup without deleting files.",
     )
     parser.add_argument(
-        "--seed-hue",
-        type=float,
-        default=None,
-        help="Seed hue (0-360) for color palette (default: 190, cyan). Env: CC_DUMP_SEED_HUE",
-    )
-    parser.add_argument(
         "--forward-proxy-ca-dir",
         type=str,
         default=None,
@@ -454,7 +448,7 @@ def main():
     )
 
     # Initialize color palette before anything else imports it
-    cc_dump.core.palette.init_palette(args.seed_hue)
+    cc_dump.core.palette.init_palette()
 
     if args.list_recordings:
         recordings = cc_dump.io.sessions.list_recordings()

--- a/src/cc_dump/core/palette.py
+++ b/src/cc_dump/core/palette.py
@@ -468,14 +468,10 @@ def _get_seed_hue() -> float:
     return 190.0
 
 
-def init_palette(seed_hue: float | None = None) -> None:
-    """Initialize the global palette with a seed hue.
-
-    Call this before TUI starts if using --seed-hue CLI arg.
-    """
+def init_palette() -> None:
+    """Initialize the global palette from the environment/default seed hue."""
     global PALETTE
-    hue = seed_hue if seed_hue is not None else _get_seed_hue()
-    PALETTE = Palette(seed_hue=hue)
+    PALETTE = Palette(seed_hue=_get_seed_hue())
 
 
 # Module-level singleton — consumers import this


### PR DESCRIPTION
## Summary
### `src/cc_dump/cli.py`
- Removed the `--seed-hue` argument from CLI parsing.
- Simplified palette startup wiring to call `init_palette()` with no CLI override path.

### `src/cc_dump/core/palette.py`
- Simplified `init_palette` to no-arg initialization from environment/default only.
- Removed optional parameter plumbing that previously allowed CLI seed injection.

### `README.md`
- Removed `--seed-hue` from CLI reference.
- Updated environment docs to keep `CC_DUMP_SEED_HUE` as the single seed-hue configuration surface.

## Removed Features
- CLI option `--seed-hue`.
- CLI-over-env seed precedence for palette initialization.

## Non-product files
- None.

## Validation
- `uv run pytest -q`
- `uv run mypy src`
- `uv run python scripts/quality_gate.py check`