### PR TITLE
Fix analytics_store import style for hot-reload compatibility

### DIFF
--- a/src/cc_dump/app/analytics_store.py
+++ b/src/cc_dump/app/analytics_store.py
@@ -355,11 +355,29 @@ def _coerce_str(value: object, *, default: str = "") -> str:
 
 
 def _coerce_int(value: object, *, default: int = 0) -> int:
-    return int(value or default)
+    if value is None or value == "":
+        return default
+    if isinstance(value, (int, float)):
+        return int(value)
+    if isinstance(value, (str, bytes, bytearray)):
+        try:
+            return int(value)
+        except ValueError:
+            return default
+    return default
 
 
 def _coerce_float(value: object, *, default: float = 0.0) -> float:
-    return float(value or default)
+    if value is None or value == "":
+        return default
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, (str, bytes, bytearray)):
+        try:
+            return float(value)
+        except ValueError:
+            return default
+    return default
 
 
 def _coerce_dict(value: object) -> dict:


### PR DESCRIPTION
## Summary

### `src/cc_dump/app`
- Replace module-object import in `analytics_store.py` with direct `parse_user_id` import from `cc_dump.core.formatting`.
- Update `_extract_session_id()` to use the direct binding.
- Make `_coerce_int()` and `_coerce_float()` mypy-safe by adding explicit type checks and parse fallbacks instead of calling `int(value or default)` / `float(value or default)` on `object`.

This aligns with the repo hot-reload import convention and keeps changed-file mypy green.

## Removed Features
- None.

## Non-product files
- None.

## Validation
- `uv run python .github/scripts/mypy_changed_files.py`
- `uv run python scripts/quality_gate.py check`
- `uv run pytest tests/test_analytics_store.py`
