### PR TITLE
Close dead-block quick win by removing stale DiffBlock docs reference

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -62,7 +62,6 @@ The IR is a flat list of `FormattedBlock` subclasses. Key types:
 | `RoleBlock` | Message role label (USER, ASSISTANT, SYSTEM) |
 | `TextContentBlock` | Plain text content |
 | `TrackedContentBlock` | Content-hashed system prompt section |
-| `DiffBlock` | Unified diff when tracked content changes |
 | `ToolUseBlock` | Tool invocation (name, input size, detail) |
 | `ToolResultBlock` | Tool result (size, error flag, correlated name) |
 | `TextDeltaBlock` | Streaming text fragment |


### PR DESCRIPTION
## Summary

### `docs/`
- Remove stale `DiffBlock` row from `docs/ARCHITECTURE.md` block-type table.
- Confirm quick-win dead symbols remain absent in code (`DiffBlock`, `LogBlock`, `get_model_economics`).

This quick-win issue was largely already complete in `origin/master` code. This PR finalizes the remaining documentation drift.

## Removed Features
- None (no product/runtime behavior changes).

## Non-product files
- `docs/ARCHITECTURE.md`

## Validation
- `rg -n "DiffBlock|LogBlock|get_model_economics" src tests -S`
- `uv run python scripts/quality_gate.py check`
