### PR TITLE
Rename overloaded expand filter action to analytics

### DIFF
--- a/src/cc_dump/tui/action_config.py
+++ b/src/cc_dump/tui/action_config.py
@@ -41,7 +41,7 @@ VIS_CYCLE = [
 VIS_TOGGLE_SPECS = {
     "vis": [("vis", None)],
     "detail": [("vis", True), ("full", None)],
-    "expand": [("vis", True), ("exp", None)],
+    "analytics": [("vis", True), ("exp", None)],
 }
 
 # [LAW:one-type-per-behavior] Toggle config for non-cycling panels

--- a/src/cc_dump/tui/action_handlers.py
+++ b/src/cc_dump/tui/action_handlers.py
@@ -74,8 +74,13 @@ def toggle_detail(app, category: str) -> None:
     _toggle_vis_dicts(app, category, "detail")
 
 
+def toggle_analytics(app, category: str) -> None:
+    _toggle_vis_dicts(app, category, "analytics")
+
+
 def toggle_expand(app, category: str) -> None:
-    _toggle_vis_dicts(app, category, "expand")
+    """Backward-compatible alias for renamed analytics toggle action."""
+    toggle_analytics(app, category)
 
 
 def cycle_vis(app, category: str) -> None:
@@ -482,4 +487,3 @@ def prev_session(app) -> None:
         conv.scroll_to_block(boundaries[-1][1], 0)
 
     _conv_action(app, _jump)
-

--- a/src/cc_dump/tui/app.py
+++ b/src/cc_dump/tui/app.py
@@ -1188,8 +1188,11 @@ class CcDumpApp(App):
     def action_toggle_detail(self, category: str):
         _actions.toggle_detail(self, category)
 
+    def action_toggle_analytics(self, category: str):
+        _actions.toggle_analytics(self, category)
+
     def action_toggle_expand(self, category: str):
-        _actions.toggle_expand(self, category)
+        self.action_toggle_analytics(category)
 
     def action_cycle_vis(self, category: str):
         _actions.cycle_vis(self, category)

--- a/src/cc_dump/tui/input_modes.py
+++ b/src/cc_dump/tui/input_modes.py
@@ -64,13 +64,13 @@ MODE_KEYMAP: dict[InputMode, dict[str, str]] = {
         "T": "toggle_detail('metadata')",
         "Y": "toggle_detail('thinking')",
 
-        # Expand toggles (q-y for categories 1-6)
-        "q": "toggle_expand('user')",
-        "w": "toggle_expand('assistant')",
-        "e": "toggle_expand('tools')",
-        "r": "toggle_expand('system')",
-        "t": "toggle_expand('metadata')",
-        "y": "toggle_expand('thinking')",
+        # Analytics detail toggles (q-y for categories 1-6)
+        "q": "toggle_analytics('user')",
+        "w": "toggle_analytics('assistant')",
+        "e": "toggle_analytics('tools')",
+        "r": "toggle_analytics('system')",
+        "t": "toggle_analytics('metadata')",
+        "y": "toggle_analytics('thinking')",
 
         # Panels (printable — NORMAL only)
         ".": "cycle_panel",
@@ -154,7 +154,7 @@ MODE_KEYMAP: dict[InputMode, dict[str, str]] = {
 FOOTER_KEYS: dict[InputMode, list[tuple[str, str]]] = {
     InputMode.NORMAL: [
         ("1-6", "filters"),
-        ("qwerty", "expand"),
+        ("qwerty", "analytics"),
         ("QWERTY", "detail"),
         (".", "panel"),
         (",", "mode"),
@@ -201,7 +201,7 @@ KEY_GROUPS: list[tuple[str, list[tuple[str, str]]]] = [
     ("Categories", [
         ("1-6", "Toggle on/off"),
         ("Q-Y", "Detail level"),
-        ("q-y", "Expand all"),
+        ("q-y", "Analytics detail"),
     ]),
     ("Panels", [
         (".", "Cycle panel"),


### PR DESCRIPTION
## Summary

### `src/cc_dump/tui`
- Rename the visibility toggle spec key from `expand` to `analytics` in `action_config.py`.
- Add `toggle_analytics()` action handler and route the canonical behavior through it.
- Keep `toggle_expand()` as a backward-compatible alias that delegates to `toggle_analytics()`.
- Add `action_toggle_analytics()` on `CcDumpApp` and route `action_toggle_expand()` through the new method.
- Update keymaps/help labels in `input_modes.py` so `qwerty` actions invoke `toggle_analytics(...)` and footer/keys help text uses `analytics` terminology.

This disambiguates filter vocabulary so future turn-level expand/collapse semantics do not overload the `expand` action name.

## Removed Features
- None. (Compatibility alias for `toggle_expand` is retained.)

## Non-product files
- None.

## Validation
- `uv run pytest tests/test_input_modes.py tests/test_textual_visibility.py`
- `uv run python scripts/quality_gate.py check`
- `uv run python .github/scripts/mypy_changed_files.py`
