### PR TITLE
Unify expansion model by removing per-block override precedence

### DIFF
--- a/docs/QUICK_REFERENCE.md
+++ b/docs/QUICK_REFERENCE.md
@@ -250,7 +250,7 @@ At FULL level, individual blocks are shown with full details.
 
 ### State Persistence
 
-- **Level changes:** Toggling visibility or detail level clears all per-block expansion overrides for that category
-- **Click expansion:** Creates per-block overrides that persist until you change the level
+- **Level changes:** Toggling visibility or detail level resets category expansion state for that category
+- **No per-block expansion layer:** Expansion is controlled by category/turn-level state; region-level collapse (for segmented content) is tracked separately
 - **Remembered detail:** When you hide a category (level 1), it remembers whether it was at SUMMARY (2) or FULL (3), so toggling visibility restores the previous detail level
 - **Session:** Follow mode and scroll position persist across hot-reloads

--- a/src/cc_dump/tui/action_handlers.py
+++ b/src/cc_dump/tui/action_handlers.py
@@ -46,7 +46,7 @@ def _toggle_vis_dicts(app, category: str, spec_key: str) -> None:
 
 
 def clear_overrides(app, category_name: str) -> None:
-    """Reset per-block expanded overrides and content region states for a category.
+    """Reset region expansion overrides for a category.
 
     // [LAW:one-source-of-truth] Clears via ViewOverrides.clear_category() only.
     // [LAW:one-source-of-truth] Reads blocks from domain store.
@@ -108,7 +108,7 @@ def cycle_vis(app, category: str) -> None:
     next_idx = (idx + 1) % len(vis_cycle)
     next_state = vis_cycle[next_idx]
 
-    # Clear per-block overrides and invalidate active filterset
+    # Clear region overrides and invalidate active filterset
     clear_overrides(app, category)
     app._view_store.set("filter:active", None)
 

--- a/src/cc_dump/tui/rendering_impl.py
+++ b/src/cc_dump/tui/rendering_impl.py
@@ -485,15 +485,13 @@ def get_category(block: FormattedBlock) -> Category | None:
     return BLOCK_CATEGORY.get(type(block).__name__)
 
 
-def _resolve_visibility(block: FormattedBlock, filters: dict, overrides=None) -> VisState:
+def _resolve_visibility(block: FormattedBlock, filters: dict) -> VisState:
     """Determine VisState for a block given current filter state.
 
     // [LAW:one-source-of-truth] Returns THE visibility representation.
     // [LAW:dataflow-not-control-flow] Value coalescing, not branching.
-    // [LAW:single-enforcer] ViewOverrides is the sole source for per-block overrides.
 
     Filters contain VisState values keyed by category name.
-    Per-block expanded (from overrides) overrides category-level expansion.
     Returns ALWAYS_VISIBLE for blocks with no category.
     """
     cat = get_category(block)
@@ -501,15 +499,7 @@ def _resolve_visibility(block: FormattedBlock, filters: dict, overrides=None) ->
         return ALWAYS_VISIBLE  # always fully visible
 
     vis = filters.get(cat.value, ALWAYS_VISIBLE)
-    # Per-block expanded override — from overrides only
-    block_expanded = None
-    if overrides is not None:
-        bvs = overrides._blocks.get(block.block_id)
-        if bvs is not None:
-            block_expanded = bvs.expanded
-    expanded = block_expanded if block_expanded is not None else vis.expanded
-
-    return VisState(vis.visible, vis.full, expanded)
+    return VisState(vis.visible, vis.full, vis.expanded)
 
 
 # ─── Style helpers ─────────────────────────────────────────────────────────────
@@ -3808,7 +3798,7 @@ def _render_block_tree(block: FormattedBlock, ctx: _RenderContext) -> None:
     // [LAW:single-enforcer] Visibility/render/truncation/recursion policy is enforced here.
     // [LAW:dataflow-not-control-flow] Pipeline stages always execute in the same order.
     """
-    vis = _resolve_visibility(block, ctx.filters, overrides=ctx.overrides)
+    vis = _resolve_visibility(block, ctx.filters)
     max_lines = TRUNCATION_LIMITS[vis]
     if max_lines == 0:
         return

--- a/src/cc_dump/tui/view_overrides.py
+++ b/src/cc_dump/tui/view_overrides.py
@@ -20,7 +20,6 @@ from cc_dump.tui.rendering import get_category
 class BlockViewState:
     """Per-block view state, keyed by block_id."""
 
-    expanded: bool | None = None  # click toggle override
     expandable: bool = False  # renderer-computed
 
 
@@ -61,7 +60,7 @@ class ViewOverrides:
         return state
 
     def clear_category(self, blocks: Iterable[FormattedBlock], category: Category) -> None:
-        """Reset expanded overrides for all blocks matching a category.
+        """Reset region expanded overrides for all blocks matching a category.
 
         Recursively walks children.
         """
@@ -69,10 +68,7 @@ class ViewOverrides:
             for block in block_list:
                 block_cat = get_category(block)
                 if block_cat == category:
-                    bvs = self._blocks.get(block.block_id)
-                    if bvs is not None:
-                        bvs.expanded = None
-                    # Clear region overrides
+                    # // [LAW:one-source-of-truth] Region expansion overrides live only in _regions.
                     for region in block.content_regions:
                         key = (block.block_id, region.index)
                         rvs = self._regions.get(key)
@@ -90,8 +86,6 @@ class ViewOverrides:
         blocks = {}
         for bid, bvs in self._blocks.items():
             entry = {}
-            if bvs.expanded is not None:
-                entry["expanded"] = bvs.expanded
             if bvs.expandable:
                 entry["expandable"] = True
             if entry:
@@ -115,7 +109,6 @@ class ViewOverrides:
         for bid_str, entry in data.get("blocks", {}).items():
             bid = int(bid_str) if isinstance(bid_str, str) else bid_str
             bvs = BlockViewState(
-                expanded=entry.get("expanded"),
                 expandable=entry.get("expandable", False),
             )
             vo._blocks[bid] = bvs

--- a/tests/test_hot_reload.py
+++ b/tests/test_hot_reload.py
@@ -593,8 +593,8 @@ class TestWidgetStatePreservation:
 
         assert new_widget._follow_state == FollowState.OFF
 
-    def test_conversation_view_blocks_preserve_expansion(self):
-        """Block expanded overrides survive roundtrip via ViewOverrides serialization."""
+    def test_conversation_view_blocks_preserve_expandable_metadata(self):
+        """Block expandability metadata survives roundtrip via ViewOverrides serialization."""
         from cc_dump.core.formatting import TextContentBlock
         from cc_dump.tui.widget_factory import ConversationView, TurnData
 
@@ -605,17 +605,17 @@ class TestWidgetStatePreservation:
         td = TurnData(turn_index=0, blocks=[block_a, block_b], strips=[])
         widget._turns.append(td)
 
-        # Set expanded overrides via ViewOverrides
-        widget._view_overrides.get_block(block_a.block_id).expanded = True
-        widget._view_overrides.get_block(block_b.block_id).expanded = False
+        # Set expandability metadata via ViewOverrides
+        widget._view_overrides.get_block(block_a.block_id).expandable = True
+        widget._view_overrides.get_block(block_b.block_id).expandable = False
 
         state = widget.get_state()
         new_widget = ConversationView()
         new_widget.restore_state(state)
 
-        # ViewOverrides roundtrip preserves expanded state
-        assert new_widget._view_overrides.get_block(block_a.block_id).expanded is True
-        assert new_widget._view_overrides.get_block(block_b.block_id).expanded is False
+        # ViewOverrides roundtrip preserves block metadata
+        assert new_widget._view_overrides.get_block(block_a.block_id).expandable is True
+        assert new_widget._view_overrides.get_block(block_b.block_id).expandable is False
 
     def test_conversation_view_follow_state_active_roundtrip(self):
         """follow_state=ACTIVE explicitly survives roundtrip."""

--- a/tests/test_view_overrides.py
+++ b/tests/test_view_overrides.py
@@ -57,26 +57,25 @@ def test_block_id_monotonic():
 
 
 def test_view_overrides_clear_category():
-    """Set overrides on 3 categories, clear one — other two unchanged."""
+    """Set region overrides on 2 categories, clear one — the other remains."""
     _setup_theme()
 
     vo = ViewOverrides()
 
     user_block = TextContentBlock(content="hi", category=Category.USER)
     asst_block = TextContentBlock(content="hello", category=Category.ASSISTANT)
-    tool_block = ToolUseBlock(name="Read", input_size=10, msg_color_idx=0)
+    populate_content_regions(user_block)
+    populate_content_regions(asst_block)
 
-    # Set expanded overrides
-    vo.get_block(user_block.block_id).expanded = True
-    vo.get_block(asst_block.block_id).expanded = False
-    vo.get_block(tool_block.block_id).expanded = True
+    # Set region overrides
+    vo.get_region(user_block.block_id, 0).expanded = False
+    vo.get_region(asst_block.block_id, 0).expanded = False
 
     # Clear only USER category
-    vo.clear_category([user_block, asst_block, tool_block], Category.USER)
+    vo.clear_category([user_block, asst_block], Category.USER)
 
-    assert vo.get_block(user_block.block_id).expanded is None  # cleared
-    assert vo.get_block(asst_block.block_id).expanded is False  # untouched
-    assert vo.get_block(tool_block.block_id).expanded is True  # untouched
+    assert vo.get_region(user_block.block_id, 0).expanded is None  # cleared
+    assert vo.get_region(asst_block.block_id, 0).expanded is False  # untouched
 
 
 # ─── AC4: serialization round-trip ────────────────────────────────────────
@@ -89,9 +88,8 @@ def test_view_overrides_serialization():
     b1 = TextContentBlock(content="one")
     b2 = TextContentBlock(content="two")
 
-    vo.get_block(b1.block_id).expanded = True
     vo.get_block(b1.block_id).expandable = True
-    vo.get_block(b2.block_id).expanded = False
+    vo.get_block(b2.block_id).expandable = False
 
     vo.get_region(b1.block_id, 0).expanded = False
     vo.get_region(b1.block_id, 1).expanded = None  # default — not serialized
@@ -100,9 +98,8 @@ def test_view_overrides_serialization():
     restored = ViewOverrides.from_dict(data)
 
     # Block state
-    assert restored.get_block(b1.block_id).expanded is True
     assert restored.get_block(b1.block_id).expandable is True
-    assert restored.get_block(b2.block_id).expanded is False
+    assert restored.get_block(b2.block_id).expandable is False
 
     # Region state
     assert restored.get_region(b1.block_id, 0).expanded is False
@@ -158,7 +155,6 @@ def test_auto_create_on_miss():
     vo = ViewOverrides()
     bvs = vo.get_block(999)
     assert isinstance(bvs, BlockViewState)
-    assert bvs.expanded is None
     assert bvs.expandable is False
 
     rvs = vo.get_region(999, 0)


### PR DESCRIPTION
## Summary
This change removes the per-block expanded override layer from the TUI visibility pipeline so expansion state is resolved from category/turn-level visibility plus region-specific overrides only.

## Behavior Changes
### `src/cc_dump/tui/rendering_impl.py`
- Removed per-block `ViewOverrides._blocks[].expanded` precedence from `_resolve_visibility()`.
- Visibility now resolves `expanded` directly from category filter state.

### `src/cc_dump/tui/view_overrides.py`
- Removed `BlockViewState.expanded` from the override model.
- `clear_category()` now resets region-level expansion overrides only.
- Serialization/deserialization for block overrides now persists `expandable` metadata only.

### `src/cc_dump/tui/action_handlers.py`
- Updated `clear_overrides()` semantics/docs to reflect region-level override clearing.

### `tests/`
- Updated view-override and hot-reload tests to stop asserting removed per-block expanded state.
- Added/updated assertions around surviving override model (`expandable` metadata + region overrides).

## Removed Functionality
- Removed the per-block expanded override precedence path (`global/category expanded -> block expanded override`).

## Non-product files
- `docs/QUICK_REFERENCE.md` updated to remove stale per-block expansion behavior notes and document category/turn-level expansion model.

## Validation
- `uv run pytest tests/test_view_overrides.py tests/test_hot_reload.py tests/test_textual_visibility.py`
- `uv run pytest tests/test_gutter_rendering.py tests/test_xml_collapse.py`
- `uv run python scripts/quality_gate.py check`
- `uv run python .github/scripts/mypy_changed_files.py`

## Tracker
- Ref: `lit-9ccff100-be781feb`
