### PR TITLE
test: stabilize footer log-row assertion

### DIFF
--- a/tests/test_footer_rendering.py
+++ b/tests/test_footer_rendering.py
@@ -111,5 +111,5 @@ class TestFooterMarkupRendering:
     def test_footer_shows_log_path_when_idle(self, class_proc):
         """Log-path row shows log file path when no streams are active."""
         proc = class_proc
-        content = _get_footer_content(proc)
+        content = wait_for_content(proc, lambda c: "log:" in c.lower(), timeout=5)
         assert "log:" in content.lower(), f"Expected 'log:' row. Content:\n{content}"


### PR DESCRIPTION
## Summary
- make tests/test_footer_rendering.py::test_footer_shows_log_path_when_idle wait specifically for the log row before asserting
- remove timing sensitivity where shared PTY content could be sampled before the third footer row rendered

## Behavior Changes by Subsystem
- tests/: footer rendering PTY assertion now uses a log-row-specific wait predicate

## Removed Functionality
- none

## Non-product files
- none

## Validation
- uv run pytest -q
- uv run mypy src
- uv run python scripts/quality_gate.py check
